### PR TITLE
feat: add break statements for while loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCES
     src/AST/ReturnNode.cpp
     src/AST/IfStatementNode.cpp
     src/AST/WhileStatementNode.cpp
+    src/AST/BreakNode.cpp
     src/AST/ComparisonNode.cpp
     src/AST/LogicalNode.cpp
     src/AST/UnaryNode.cpp
@@ -159,6 +160,7 @@ set(HEADERS
     src/AST/ReturnNode.hpp
     src/AST/IfStatementNode.hpp
     src/AST/WhileStatementNode.hpp
+    src/AST/BreakNode.hpp
     src/AST/ComparisonNode.hpp
     src/AST/LogicalNode.hpp
     src/AST/UnaryNode.hpp

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **🌐 URL Library**: Complete `url` library with 26 methods for URL parsing, construction, manipulation, and validation
 - **🔄 Regular Expressions**: Complete `regexp` library with 12 methods for pattern matching, text searching, and string manipulation
 - **🔀 Control Flow Enhancement**: `else if` syntax support for complex conditional logic with proper AST chaining
+- **🛑 Break Statements**: `break` statement for early exit from while loops, enabling search patterns and safety limits
 - **📏 Text Length Method**: `Text.length()` method for string length calculation with full type integration
 - **📐 Math Library**: Comprehensive mathematical functions library with 40+ methods including trigonometry, logarithms, statistics, and constants (`import math`)
 - **✨ Comprehensive Text Methods**: 48 string manipulation methods including case conversion, search, validation, formatting, and advanced utilities
@@ -732,6 +733,73 @@ Object IterationDemo {
     }
 }
 ```
+
+### **Break Statements in While Loops**
+
+The `break` statement provides early exit from while loops, enabling powerful control flow patterns for search, filtering, and conditional processing.
+
+```obq
+import system.io
+
+Object BreakDemo {
+    @external method basicBreakExample(): Int {
+        # Exit loop when condition is met
+        i: Int = 1
+        while (i <= 10) {
+            io.print("Iteration: %d", i)
+            if (i == 5) {
+                io.print("Breaking at iteration 5")
+                break
+            }
+            i = i + 1
+        }
+        io.print("Final value: %d", i)  # Output: 5
+        return i
+    }
+    
+    @external method findFirstMatch(): Int {
+        # Search through list and exit when target found
+        numbers: List<Int> = [1, 3, 7, 8, 9, 10, 11]
+        iter: ListIterator = numbers.iterator()
+        found: Int = -1
+        
+        while (iter.hasNext()) {
+            current: Int = iter.next()
+            remainder: Int = current % 2
+            if (remainder == 0) {
+                io.print("Found first even number: %d", current)
+                found = current
+                break  # Exit immediately when found
+            }
+        }
+        return found  # Returns 8
+    }
+    
+    @external method limitedSearch(): Int {
+        # Break after maximum attempts
+        attempt: Int = 0
+        max_attempts: Int = 5
+        
+        while (true) {  # Infinite loop with break condition
+            attempt = attempt + 1
+            io.print("Attempt: %d", attempt)
+            
+            if (attempt >= max_attempts) {
+                io.print("Maximum attempts reached")
+                break
+            }
+        }
+        return attempt
+    }
+}
+```
+
+**Key Break Statement Features:**
+- ✅ **Immediate Exit**: Exits the innermost while loop instantly
+- ✅ **Search Patterns**: Perfect for find-first operations
+- ✅ **Safety Limits**: Prevents infinite loops with max iteration checks
+- ✅ **Nested Loops**: Only exits the immediate while loop (not outer loops)
+- ✅ **Iterator Compatible**: Works seamlessly with all iterator types
 
 ### **Generic Sets (Set<T>) with Iterators**
 
@@ -3321,6 +3389,7 @@ try {
 | `import`                  | Import system modules              |
 | `if`, `else if`, `else`   | Conditional logic with chaining    |
 | `while`                   | Control flow loop                  |
+| `break`                   | Exit from while loop               |
 | `throw`                   | Throw user-defined errors          |
 | `try`, `catch`, `finally` | Structured exception handling      |
 | `Result`, `Error`         | Error handling types               |
@@ -3843,6 +3912,7 @@ Immutable objects eliminate entire categories of bugs:
 - ✅ **128-bit Integer Support**: Long type with extended precision
 - ✅ **Comprehensive Type System**: Int, Long, Float, Double with automatic promotion
 - ✅ **While Loops**: Practical iteration with ListIterator and RepeatIterator support
+- ✅ **Break Statements**: Early exit from while loops for search patterns and safety limits
 - ✅ **Modulo Operator**: Full arithmetic completeness with `%` operator for all numeric types
 - ✅ **System Utilities**: `system.utils` module with RepeatIterator for controlled repetition
 - ✅ **Error Handling System**: Complete `throw`/`try`/`catch`/`finally` with `Result<T,E>` and `Error` types

--- a/examples/test_break_examples.obq
+++ b/examples/test_break_examples.obq
@@ -1,0 +1,176 @@
+import system.io
+
+Object BreakExamples {
+    @external method basicBreakExample(): Int {
+        io.print("=== Basic Break Example ===")
+        
+        i: Int = 1
+        while (i <= 10) {
+            io.print("Iteration: %d", i)
+            if (i == 5) {
+                io.print("Breaking at iteration 5")
+                break
+            }
+            i = i + 1
+        }
+        
+        io.print("Final value of i: %d", i)
+        return i
+    }
+    
+    @external method findFirstEvenExample(): Int {
+        io.print("=== Find First Even Number Example ===")
+        
+        numbers: List<Int> = [1, 3, 7, 8, 9, 10, 11]
+        io.print("Numbers: %s", numbers)
+        
+        iter: ListIterator = numbers.iterator()
+        found: Int = -1
+        
+        while (iter.hasNext()) {
+            current: Int = iter.next()
+            io.print("Checking number: %d", current)
+            
+            remainder: Int = current % 2
+            if (remainder == 0) {
+                io.print("Found first even number: %d", current)
+                found = current
+                break
+            }
+        }
+        
+        if (found == -1) {
+            io.print("No even number found")
+        }
+        
+        return found
+    }
+    
+    @external method searchWithLimitExample(): Int {
+        io.print("=== Search with Limit Example ===")
+        
+        target: Int = 42
+        attempt: Int = 0
+        max_attempts: Int = 5
+        found: Bool = false
+        
+        # Simulate searching for a target value
+        search_values: List<Int> = [10, 25, 42, 15, 8]
+        iter: ListIterator = search_values.iterator()
+        
+        io.print("Searching for: %d", target)
+        io.print("Max attempts: %d", max_attempts)
+        
+        while (iter.hasNext()) {
+            attempt = attempt + 1
+            current: Int = iter.next()
+            
+            io.print("Attempt %d: checking %d", attempt, current)
+            
+            if (current == target) {
+                io.print("Target found!")
+                found = true
+                break
+            }
+            
+            if (attempt >= max_attempts) {
+                io.print("Maximum attempts reached")
+                break
+            }
+        }
+        
+        if (found) {
+            io.print("Search successful in %d attempts", attempt)
+            return attempt
+        } else {
+            io.print("Search failed after %d attempts", attempt)
+            return -1
+        }
+    }
+    
+    @external method sumUntilThresholdExample(): Int {
+        io.print("=== Sum Until Threshold Example ===")
+        
+        threshold: Int = 50
+        sum: Int = 0
+        i: Int = 1
+        
+        io.print("Adding numbers until sum exceeds %d", threshold)
+        
+        while (true) {
+            sum = sum + i
+            io.print("Added %d, sum is now %d", i, sum)
+            
+            if (sum > threshold) {
+                io.print("Threshold exceeded, breaking")
+                break
+            }
+            
+            i = i + 1
+        }
+        
+        io.print("Final sum: %d", sum)
+        return sum
+    }
+    
+    @external method nestedLoopBreakExample(): Int {
+        io.print("=== Nested Loop Break Example ===")
+        
+        # This demonstrates that break only exits the innermost while loop
+        outer_count: Int = 0
+        total_operations: Int = 0
+        
+        while (outer_count < 3) {
+            outer_count = outer_count + 1
+            io.print("Outer loop iteration: %d", outer_count)
+            
+            inner_count: Int = 0
+            while (inner_count < 10) {
+                inner_count = inner_count + 1
+                total_operations = total_operations + 1
+                
+                io.print("  Inner loop iteration: %d", inner_count)
+                
+                if (inner_count == 3) {
+                    io.print("  Breaking inner loop at count 3")
+                    break
+                }
+            }
+        }
+        
+        io.print("Total operations: %d", total_operations)
+        return total_operations
+    }
+    
+    @external method runAllExamples(): Int {
+        io.print("Break Statement Examples")
+        io.print("========================")
+        io.print("")
+        
+        this.basicBreakExample()
+        io.print("")
+        
+        this.findFirstEvenExample()
+        io.print("")
+        
+        this.searchWithLimitExample()
+        io.print("")
+        
+        this.sumUntilThresholdExample()
+        io.print("")
+        
+        this.nestedLoopBreakExample()
+        
+        io.print("")
+        io.print("All break statement examples completed!")
+        
+        return 0
+    }
+}
+
+Object Main {
+    method main(): Int {
+        examples: BreakExamples = new BreakExamples()
+        return examples.runAllExamples()
+    }
+}

--- a/src/AST/BreakNode.cpp
+++ b/src/AST/BreakNode.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BreakNode.hpp"
+
+#include "../Common/Exceptions.hpp"
+
+namespace o2l {
+
+Value BreakNode::evaluate(Context& context) {
+    throw BreakException();
+}
+
+std::string BreakNode::toString() const {
+    return "Break()";
+}
+
+}  // namespace o2l

--- a/src/AST/BreakNode.hpp
+++ b/src/AST/BreakNode.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Node.hpp"
+
+namespace o2l {
+
+class BreakNode : public ASTNode {
+public:
+    BreakNode() = default;
+
+    Value evaluate(Context& context) override;
+    std::string toString() const override;
+};
+
+}  // namespace o2l

--- a/src/AST/WhileStatementNode.cpp
+++ b/src/AST/WhileStatementNode.cpp
@@ -43,10 +43,12 @@ Value WhileStatementNode::evaluate(Context& context) {
         }
 
         // Execute the body
-        result = body_->evaluate(context);
-
-        // Note: In a more sophisticated implementation, we might want to handle
-        // break/continue statements here, but for now we keep it simple
+        try {
+            result = body_->evaluate(context);
+        } catch (const BreakException&) {
+            // Break statement was executed, exit the while loop
+            break;
+        }
     }
 
     return result;  // Return the last result from the body

--- a/src/Common/Exceptions.hpp
+++ b/src/Common/Exceptions.hpp
@@ -148,6 +148,16 @@ public:
     }
 };
 
+// Special exception for handling break statements - not an error, but control flow
+class BreakException : public std::exception {
+public:
+    BreakException() = default;
+    
+    const char* what() const noexcept override {
+        return "Break statement executed (not an error)";
+    }
+};
+
 // Exception for user-thrown errors via throw statements
 class UserException : public o2lException {
 private:

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -242,6 +242,7 @@ TokenType Lexer::getKeywordType(const std::string& identifier) const {
     if (identifier == "if") return TokenType::IF;
     if (identifier == "else") return TokenType::ELSE;
     if (identifier == "while") return TokenType::WHILE;
+    if (identifier == "break") return TokenType::BREAK;
     if (identifier == "return") return TokenType::RETURN;
     if (identifier == "this") return TokenType::THIS;
     if (identifier == "true") return TokenType::TRUE;

--- a/src/Lexer.hpp
+++ b/src/Lexer.hpp
@@ -35,6 +35,7 @@ enum class TokenType {
     IF,
     ELSE,
     WHILE,
+    BREAK,
     RETURN,
     THIS,
     TRUE,

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -37,6 +37,7 @@
 #include "AST/ConstDeclarationNode.hpp"
 #include "AST/IfStatementNode.hpp"
 #include "AST/WhileStatementNode.hpp"
+#include "AST/BreakNode.hpp"
 #include "AST/ComparisonNode.hpp"
 #include "AST/LogicalNode.hpp"
 #include "AST/UnaryNode.hpp"
@@ -1016,6 +1017,11 @@ ASTNodePtr Parser::parseStatement() {
         return parseWhileStatement();
     }
     
+    // Check for break statements
+    if (token.type == TokenType::BREAK) {
+        return parseBreakStatement();
+    }
+    
     // Check for throw statements
     if (token.type == TokenType::THROW) {
         return parseThrowStatement();
@@ -1650,6 +1656,16 @@ ASTNodePtr Parser::parseWhileStatement() {
     SourceLocation location(filename_, while_token.line, while_token.column);
     while_statement->setSourceLocation(location);
     return while_statement;
+}
+
+ASTNodePtr Parser::parseBreakStatement() {
+    Token break_token = consume(TokenType::BREAK, "Expected 'break'");
+    
+    auto break_node = std::make_unique<BreakNode>();
+    SourceLocation break_location(filename_, break_token.line, break_token.column);
+    break_node->setSourceLocation(break_location);
+    
+    return break_node;
 }
 
 std::string Parser::parseTypeName() {

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -67,6 +67,7 @@ class Parser {
     ASTNodePtr parseConstDeclaration();
     ASTNodePtr parseIfStatement();
     ASTNodePtr parseWhileStatement();
+    ASTNodePtr parseBreakStatement();
     ASTNodePtr parseEnumDeclaration();
     ASTNodePtr parseRecordDeclaration();
     ASTNodePtr parseProtocolDeclaration();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_SOURCES_LIST
     test_o2l_fmt.cpp
     test_ffi_simplified.cpp
     test_ffi_library.cpp
+    test_break_statement.cpp
     test_main.cpp
 )
 
@@ -108,3 +109,4 @@ add_test(NAME protocol_signature_validation_tests COMMAND o2l_tests --gtest_filt
 add_test(NAME o2l_fmt_tests COMMAND o2l_tests --gtest_filter="O2LFmtTest.*")
 add_test(NAME ffi_simplified_tests COMMAND o2l_tests --gtest_filter="FFISimplifiedTest.*")
 add_test(NAME ffi_library_tests COMMAND o2l_tests --gtest_filter="FFILibraryTest.*")
+add_test(NAME break_statement_tests COMMAND o2l_tests --gtest_filter="BreakStatementTest.*")

--- a/tests/test_break_statement.cpp
+++ b/tests/test_break_statement.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "AST/BreakNode.hpp"
+#include "AST/ObjectNode.hpp"
+#include "AST/WhileStatementNode.hpp"
+#include "Interpreter.hpp"
+#include "Lexer.hpp"
+#include "Parser.hpp"
+
+using namespace o2l;
+
+class BreakStatementTest : public ::testing::Test {
+   protected:
+    void SetUp() override {}
+
+    std::vector<ASTNodePtr> parse(const std::string& input) {
+        Lexer lexer(input);
+        auto tokens = lexer.tokenizeAll();
+        Parser parser(std::move(tokens));
+        return parser.parse();
+    }
+
+    Value interpret(const std::string& input) {
+        auto nodes = parse(input);
+        Interpreter interpreter;
+        return interpreter.execute(nodes);
+    }
+};
+
+// Test break statement parsing
+TEST_F(BreakStatementTest, BreakStatementParsing) {
+    auto nodes = parse(R"(
+        Object TestObject {
+            method test(): Int {
+                i: Int = 0
+                while (i < 10) {
+                    i = i + 1
+                    if (i == 5) {
+                        break
+                    }
+                }
+                return i
+            }
+        }
+    )");
+
+    ASSERT_EQ(nodes.size(), 1);
+    auto object_node = dynamic_cast<ObjectNode*>(nodes[0].get());
+    ASSERT_NE(object_node, nullptr);
+    EXPECT_EQ(object_node->getName(), "TestObject");
+}
+
+// Test break statement lexing
+TEST_F(BreakStatementTest, BreakTokenLexing) {
+    Lexer lexer("break");
+    auto tokens = lexer.tokenizeAll();
+    
+    ASSERT_EQ(tokens.size(), 2); // break + EOF
+    EXPECT_EQ(tokens[0].type, TokenType::BREAK);
+    EXPECT_EQ(tokens[0].value, "break");
+    EXPECT_EQ(tokens[1].type, TokenType::EOF_TOKEN);
+}
+
+// Test basic break functionality in while loop
+TEST_F(BreakStatementTest, BasicBreakInWhile) {
+    auto result = interpret(R"(
+        Object Main {
+            method main(): Int {
+                i: Int = 0
+                while (i < 10) {
+                    i = i + 1
+                    if (i == 5) {
+                        break
+                    }
+                }
+                return i
+            }
+        }
+    )");
+
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 5);
+}
+
+// Test break in nested conditions
+TEST_F(BreakStatementTest, BreakInNestedCondition) {
+    auto result = interpret(R"(
+        Object Main {
+            method main(): Int {
+                count: Int = 0
+                i: Int = 1
+                while (i <= 20) {
+                    if (i > 3) {
+                        if (i < 8) {
+                            count = count + 1
+                            if (count == 3) {
+                                break
+                            }
+                        }
+                    }
+                    i = i + 1
+                }
+                return i
+            }
+        }
+    )");
+
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 6);
+}
+
+// Test break with list iteration
+TEST_F(BreakStatementTest, BreakWithListIteration) {
+    auto result = interpret(R"(
+        Object Main {
+            method main(): Int {
+                numbers: List<Int> = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                iter: ListIterator = numbers.iterator()
+                count: Int = 0
+                
+                while (iter.hasNext()) {
+                    value: Int = iter.next()
+                    count = count + 1
+                    if (value == 6) {
+                        break
+                    }
+                }
+                
+                return count
+            }
+        }
+    )");
+
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 6);
+}
+
+// Test break with early termination
+TEST_F(BreakStatementTest, BreakEarlyTermination) {
+    auto result = interpret(R"(
+        Object Main {
+            method main(): Int {
+                sum: Int = 0
+                i: Int = 1
+                
+                while (true) {
+                    sum = sum + i
+                    i = i + 1
+                    if (sum > 50) {
+                        break
+                    }
+                }
+                
+                return sum
+            }
+        }
+    )");
+
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    // 1+2+3+4+5+6+7+8+9+10 = 55
+    EXPECT_EQ(std::get<Int>(result), 55);
+}
+
+// Test multiple break statements (only first should execute)
+TEST_F(BreakStatementTest, MultipleBreakStatements) {
+    auto result = interpret(R"(
+        Object Main {
+            method main(): Int {
+                i: Int = 0
+                while (i < 10) {
+                    i = i + 1
+                    if (i == 3) {
+                        break
+                    }
+                    if (i == 7) {
+                        break
+                    }
+                }
+                return i
+            }
+        }
+    )");
+
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 3);
+}


### PR DESCRIPTION
This pull request adds support for the `break` statement to the language, allowing early exit from `while` loops. The implementation includes updates to the lexer, parser, AST, and runtime, as well as documentation and example/test coverage. This feature enables more expressive control flow, such as search patterns and iteration limits.

### Language Feature: Break Statement
* Added `break` statement support for early exit from `while` loops, including AST node (`BreakNode`), parser logic, and runtime handling via a dedicated exception (`BreakException`). [[1]](diffhunk://#diff-2e79268baddc7343dc17f51592abdfad1902938b9bc38143b24e88243fa87357R1-R31) [[2]](diffhunk://#diff-e34cb07c42a5de274c7cf4c535928bd6adfb6a2a2fbd2012d716351664d69a05R1-R31) [[3]](diffhunk://#diff-738570706dfcfc8595baecaf8bdd213669bb87f07476d8368f5deffa298ecab7R151-R160) [[4]](diffhunk://#diff-f43befac4a4d307adaf8ecca5f1a8ae331df586a35fe69d1e097650aed58c56aR40) [[5]](diffhunk://#diff-f43befac4a4d307adaf8ecca5f1a8ae331df586a35fe69d1e097650aed58c56aR1020-R1024) [[6]](diffhunk://#diff-f43befac4a4d307adaf8ecca5f1a8ae331df586a35fe69d1e097650aed58c56aR1661-R1670) [[7]](diffhunk://#diff-354953dbdd8e5ac4db49a082f02176a9e81781b81433cd8950c6661789ed69ddR46-R51) [[8]](diffhunk://#diff-317ae66d3cd5ea5a60d40989dffa9bb8bb4d9d7480e82745616f039571427c4cR70)

### Lexer and Parser Updates
* Updated lexer to recognize `break` as a keyword and added its token type. [[1]](diffhunk://#diff-2b9637367a98fa65c55c8e04d2959d62e5bc19ea29190b4b7931b3a403200a1bR245) [[2]](diffhunk://#diff-9f721061fff8d6e62cf21e738d7a044764158288af4423f0a135143e534d91ecR38)
* Integrated `BreakNode` into the parser and AST build process. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR85) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR163) [[3]](diffhunk://#diff-f43befac4a4d307adaf8ecca5f1a8ae331df586a35fe69d1e097650aed58c56aR40) [[4]](diffhunk://#diff-f43befac4a4d307adaf8ecca5f1a8ae331df586a35fe69d1e097650aed58c56aR1020-R1024) [[5]](diffhunk://#diff-f43befac4a4d307adaf8ecca5f1a8ae331df586a35fe69d1e097650aed58c56aR1661-R1670) [[6]](diffhunk://#diff-317ae66d3cd5ea5a60d40989dffa9bb8bb4d9d7480e82745616f039571427c4cR70)

### Documentation and Examples
* Documented the new `break` statement in `README.md`, including usage, features, and example code snippets. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R737-R803) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3392) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3915)
* Added comprehensive example file `examples/test_break_examples.obq` demonstrating various break statement scenarios.

### Testing
* Added unit test source and registration for break statement functionality in the test suite. [[1]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR44) [[2]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR112)