### PR TITLE
feat: add green threads (cooperative concurrency) with spawn, Channel, and async I/O

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ o2l
 
 # Test files (optional - remove if you want to track test .obq files)
 *.obq.test
+
+# bv (beads viewer) local config and caches
+.bv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SOURCES
     src/AST/WhileStatementNode.cpp
     src/AST/BreakNode.cpp
     src/AST/ContinueNode.cpp
+    src/AST/SpawnNode.cpp
     src/AST/ComparisonNode.cpp
     src/AST/LogicalNode.cpp
     src/AST/UnaryNode.cpp
@@ -102,6 +103,11 @@ set(SOURCES
     src/Runtime/Value.cpp
     src/Runtime/ObjectInstance.cpp
     src/Runtime/Context.cpp
+    src/Runtime/Coroutine.cpp
+    src/Runtime/Scheduler.cpp
+    src/Runtime/ChannelInstance.cpp
+    src/Runtime/ConcurrencyLibrary.cpp
+    src/Runtime/IOThreadPool.cpp
     src/Runtime/ModuleLoader.cpp
     src/Runtime/SystemLibrary.cpp
     src/Runtime/MathLibrary.cpp
@@ -166,6 +172,7 @@ set(HEADERS
     src/AST/WhileStatementNode.hpp
     src/AST/BreakNode.hpp
     src/AST/ContinueNode.hpp
+    src/AST/SpawnNode.hpp
     src/AST/ComparisonNode.hpp
     src/AST/LogicalNode.hpp
     src/AST/UnaryNode.hpp
@@ -180,6 +187,12 @@ set(HEADERS
     src/Runtime/Value.hpp
     src/Runtime/ObjectInstance.hpp
     src/Runtime/Context.hpp
+    src/Runtime/Coroutine.hpp
+    src/Runtime/CoroutineHandle.hpp
+    src/Runtime/Scheduler.hpp
+    src/Runtime/ChannelInstance.hpp
+    src/Runtime/ConcurrencyLibrary.hpp
+    src/Runtime/IOThreadPool.hpp
     src/Runtime/ModuleLoader.hpp
     src/Runtime/SystemLibrary.hpp
     src/Runtime/MathLibrary.hpp

--- a/examples/concurrency.obq
+++ b/examples/concurrency.obq
@@ -1,0 +1,42 @@
+// O2L Concurrency Example
+// Demonstrates green threads (spawn), channels, and async I/O
+
+Object Worker {
+    method workerRoutine(id: Int, ch: Channel) {
+        io.print("Worker %d starting...", id)
+        
+        // Simulate work with async sleep
+        io.sleep(100)
+        
+        io.print("Worker %d finished work. Sending result...", id)
+        ch.send("Result from Worker " + id.toString())
+    }
+}
+
+Object Main {
+    method main(): Text {
+        io.print("🚀 Concurrency Demo Starting")
+
+        // Create a buffered channel
+        results: Channel = Channel.new(5)
+        worker: Worker = new Worker()
+
+        io.print("Spawning workers...")
+        spawn { worker.workerRoutine(1, results) }
+        spawn { worker.workerRoutine(2, results) }
+        spawn { worker.workerRoutine(3, results) }
+
+        // Wait for results
+        io.print("Waiting for results from workers...")
+        
+        count: Int = 0
+        while (count < 3) {
+            msg: Text = results.receive()
+            io.print("Received: %s", msg)
+            count = count + 1
+        }
+
+        io.print("All workers finished!")
+        return "Demo Complete"
+    }
+}

--- a/src/AST/BlockNode.cpp
+++ b/src/AST/BlockNode.cpp
@@ -16,8 +16,11 @@
 
 #include "BlockNode.hpp"
 
+#include <iostream>
 #include "../Common/Exceptions.hpp"
 #include "../Runtime/Context.hpp"
+#include "../Runtime/Scheduler.hpp"
+#include "../Runtime/Coroutine.hpp"
 
 namespace o2l {
 
@@ -25,17 +28,40 @@ BlockNode::BlockNode(std::vector<ASTNodePtr> statements) : statements_(std::move
 
 Value BlockNode::evaluate(Context& context) {
     Value result = Int(0);  // Default return value
+    
+    size_t start_index = 0;
+    auto& scheduler = Scheduler::instance();
+    auto current_coro = scheduler.currentCoroutine();
+    
+    // Concurrency support: resume from last suspended statement
+    if (current_coro && !current_coro->block_resume_stack.empty()) {
+        start_index = current_coro->block_resume_stack.back();
+        current_coro->block_resume_stack.pop_back();
+        if (start_index > 0) {
+            std::cerr << "  [BlockNode] Resuming at index " << start_index << std::endl;
+        }
+    }
 
-    // Execute all statements in sequence
-    for (const auto& statement : statements_) {
+    for (size_t i = start_index; i < statements_.size(); ++i) {
         try {
-            result = statement->evaluate(context);
+            result = statements_[i]->evaluate(context);
         } catch (const ReturnException& e) {
-            // Return statement encountered - propagate it up to method level
+            throw;
+        } catch (const BreakException& e) {
+            throw;
+        } catch (const ContinueException& e) {
+            throw;
+        } catch (const SuspendException& e) {
+            // Save current index for resumption
+            if (current_coro) {
+                current_coro->block_resume_stack.push_back(i);
+                std::cerr << "  [BlockNode] Suspending at index " << i << std::endl;
+            }
             throw;
         }
     }
 
+    // Block finished successfully
     return result;
 }
 

--- a/src/AST/BlockNode.cpp
+++ b/src/AST/BlockNode.cpp
@@ -16,7 +16,6 @@
 
 #include "BlockNode.hpp"
 
-#include <iostream>
 #include "../Common/Exceptions.hpp"
 #include "../Runtime/Context.hpp"
 #include "../Runtime/Scheduler.hpp"
@@ -28,18 +27,15 @@ BlockNode::BlockNode(std::vector<ASTNodePtr> statements) : statements_(std::move
 
 Value BlockNode::evaluate(Context& context) {
     Value result = Int(0);  // Default return value
-    
+
     size_t start_index = 0;
     auto& scheduler = Scheduler::instance();
     auto current_coro = scheduler.currentCoroutine();
-    
+
     // Concurrency support: resume from last suspended statement
     if (current_coro && !current_coro->block_resume_stack.empty()) {
         start_index = current_coro->block_resume_stack.back();
         current_coro->block_resume_stack.pop_back();
-        if (start_index > 0) {
-            std::cerr << "  [BlockNode] Resuming at index " << start_index << std::endl;
-        }
     }
 
     for (size_t i = start_index; i < statements_.size(); ++i) {
@@ -51,11 +47,10 @@ Value BlockNode::evaluate(Context& context) {
             throw;
         } catch (const ContinueException& e) {
             throw;
-        } catch (const SuspendException& e) {
+        } catch (const SuspendException&) {
             // Save current index for resumption
             if (current_coro) {
                 current_coro->block_resume_stack.push_back(i);
-                std::cerr << "  [BlockNode] Suspending at index " << i << std::endl;
             }
             throw;
         }

--- a/src/AST/FunctionCallNode.cpp
+++ b/src/AST/FunctionCallNode.cpp
@@ -16,10 +16,14 @@
 
 #include "FunctionCallNode.hpp"
 
+#include <thread>
+#include <chrono>
+
 #include "../Common/Exceptions.hpp"
 #include "../Runtime/Context.hpp"
 #include "../Runtime/ObjectInstance.hpp"
 #include "../Runtime/ResultInstance.hpp"
+#include "../Runtime/Scheduler.hpp"
 
 namespace o2l {
 
@@ -73,6 +77,38 @@ Value FunctionCallNode::evaluate(Context& context) {
         // Create an error Result instance
         auto result_instance = ResultInstance::createError(error_value, "T", "E");
         return std::static_pointer_cast<ResultInstance>(result_instance);
+    }
+
+    // Handle sleep() built-in
+    if (function_name_ == "sleep") {
+        if (arguments_.size() != 1) {
+            throw EvaluationError("sleep() requires exactly one argument (milliseconds)");
+        }
+
+        auto& scheduler = Scheduler::instance();
+        
+        // If we just resumed from sleep, we're done
+        if (scheduler.hasResumeValue()) {
+            scheduler.consumeResumeValue();
+            return Value(Int(0));
+        }
+
+        Value ms_value = arguments_[0]->evaluate(context);
+        if (!std::holds_alternative<Int>(ms_value)) {
+            throw TypeMismatchError("sleep() argument must be an Integer");
+        }
+
+        Int ms = std::get<Int>(ms_value);
+
+        if (scheduler.isActive()) {
+            scheduler.suspendForSleep(static_cast<uint64_t>(ms));
+            // suspendForSleep throws SuspendException, so we never reach here
+        } else {
+            // Blocking fallback
+            std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+        }
+
+        return Value(Int(0));
     }
 
     throw UnresolvedReferenceError("Function '" + function_name_ + "' not found");

--- a/src/AST/MethodCallNode.cpp
+++ b/src/AST/MethodCallNode.cpp
@@ -2040,6 +2040,9 @@ Value MethodCallNode::evaluate(Context& context) {
 
         return object_instance->callMethod(method_name_, arg_values, context, is_external_call);
 
+    } catch (const SuspendException& e) {
+        // SuspendException must be allowed to propagate to the scheduler
+        throw;
     } catch (const o2lException& e) {
         // Re-throw with current context if it doesn't already have a stack trace
         if (e.getStackTrace().empty()) {

--- a/src/AST/SpawnNode.cpp
+++ b/src/AST/SpawnNode.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SpawnNode.hpp"
+#include "../Runtime/Scheduler.hpp"
+#include "../Runtime/CoroutineHandle.hpp"
+
+namespace o2l {
+
+SpawnNode::SpawnNode(ASTNodePtr body) : body_(std::move(body)) {}
+
+Value SpawnNode::evaluate(Context& context) {
+    auto& scheduler = Scheduler::instance();
+    
+    // 1. Clone context
+    Context cloned = context.clone();
+    
+    // 2. Spawn coroutine
+    uint64_t id = scheduler.spawn(body_.get(), std::move(cloned));
+    
+    // 3. Return handle
+    return Value(std::make_shared<CoroutineHandle>(id));
+}
+
+std::string SpawnNode::toString() const {
+    return "spawn " + body_->toString();
+}
+
+}  // namespace o2l

--- a/src/AST/SpawnNode.hpp
+++ b/src/AST/SpawnNode.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Node.hpp"
+
+namespace o2l {
+
+class SpawnNode : public ASTNode {
+   private:
+    ASTNodePtr body_;
+
+   public:
+    explicit SpawnNode(ASTNodePtr body);
+
+    Value evaluate(Context& context) override;
+    std::string toString() const override;
+
+    const ASTNodePtr& getBody() const {
+        return body_;
+    }
+};
+
+}  // namespace o2l

--- a/src/AST/TryCatchFinallyNode.cpp
+++ b/src/AST/TryCatchFinallyNode.cpp
@@ -39,6 +39,10 @@ Value TryCatchFinallyNode::evaluate(Context& context) {
     // Execute try block
     try {
         result = try_block_->evaluate(context);
+    } catch (const SuspendException& e) {
+        // SuspendException should not be caught by user try/catch and should NOT trigger finally.
+        // It unwinds the stack to the scheduler.
+        throw;
     } catch (const UserException& e) {
         // User threw an exception with throw statement
         exception_thrown = true;

--- a/src/AST/WhileStatementNode.cpp
+++ b/src/AST/WhileStatementNode.cpp
@@ -16,7 +16,6 @@
 
 #include "WhileStatementNode.hpp"
 
-#include <iostream>
 #include "../Common/Exceptions.hpp"
 #include "../Runtime/Scheduler.hpp"
 #include "../Runtime/Coroutine.hpp"
@@ -28,7 +27,7 @@ WhileStatementNode::WhileStatementNode(ASTNodePtr condition, ASTNodePtr body)
 
 Value WhileStatementNode::evaluate(Context& context) {
     Value result = Value{};  // Default empty value
-    
+
     auto& scheduler = Scheduler::instance();
     auto current_coro = scheduler.currentCoroutine();
 
@@ -39,9 +38,6 @@ Value WhileStatementNode::evaluate(Context& context) {
         if (current_coro && !current_coro->block_resume_stack.empty()) {
             skip_condition = current_coro->block_resume_stack.back() != 0;
             current_coro->block_resume_stack.pop_back();
-            if (skip_condition) {
-                std::cerr << "  [WhileNode] Skipping condition (resuming body)" << std::endl;
-            }
         }
 
         if (!skip_condition) {
@@ -60,7 +56,7 @@ Value WhileStatementNode::evaluate(Context& context) {
                 break;  // Exit loop if condition is false
             }
         }
-        
+
         // Execute the body
         try {
             result = body_->evaluate(context);
@@ -69,9 +65,9 @@ Value WhileStatementNode::evaluate(Context& context) {
             break;
         } catch (const ContinueException&) {
             continue;
-        } catch (const SuspendException& e) {
+        } catch (const SuspendException&) {
             if (current_coro) {
-                current_coro->block_resume_stack.push_back(1); // 1 means resuming body      
+                current_coro->block_resume_stack.push_back(1); // 1 means resuming body
             }
             throw;
         }

--- a/src/AST/WhileStatementNode.cpp
+++ b/src/AST/WhileStatementNode.cpp
@@ -16,7 +16,10 @@
 
 #include "WhileStatementNode.hpp"
 
+#include <iostream>
 #include "../Common/Exceptions.hpp"
+#include "../Runtime/Scheduler.hpp"
+#include "../Runtime/Coroutine.hpp"
 
 namespace o2l {
 
@@ -25,32 +28,52 @@ WhileStatementNode::WhileStatementNode(ASTNodePtr condition, ASTNodePtr body)
 
 Value WhileStatementNode::evaluate(Context& context) {
     Value result = Value{};  // Default empty value
+    
+    auto& scheduler = Scheduler::instance();
+    auto current_coro = scheduler.currentCoroutine();
 
     while (true) {
-        // Evaluate the condition
-        Value condition_value = condition_->evaluate(context);
-
-        // Check if condition is boolean
-        if (!std::holds_alternative<Bool>(condition_value)) {
-            throw TypeMismatchError("While condition must evaluate to Bool, got " +
-                                    o2l::getTypeName(condition_value));
+        // If we have a non-zero index, it means we suspended INSIDE the body.
+        // So we skip the condition check for this first "resume" iteration.
+        bool skip_condition = false;
+        if (current_coro && !current_coro->block_resume_stack.empty()) {
+            skip_condition = current_coro->block_resume_stack.back() != 0;
+            current_coro->block_resume_stack.pop_back();
+            if (skip_condition) {
+                std::cerr << "  [WhileNode] Skipping condition (resuming body)" << std::endl;
+            }
         }
 
-        // Check if condition is true
-        bool condition_bool = std::get<Bool>(condition_value);
-        if (!condition_bool) {
-            break;  // Exit loop if condition is false
-        }
+        if (!skip_condition) {
+            // Evaluate the condition
+            Value condition_value = condition_->evaluate(context);
 
+            // Check if condition is boolean
+            if (!std::holds_alternative<Bool>(condition_value)) {
+                throw TypeMismatchError("While condition must evaluate to Bool, got " +
+                                        o2l::getTypeName(condition_value));
+            }
+
+            // Check if condition is true
+            bool condition_bool = std::get<Bool>(condition_value);
+            if (!condition_bool) {
+                break;  // Exit loop if condition is false
+            }
+        }
+        
         // Execute the body
         try {
             result = body_->evaluate(context);
+            // If body completes without suspension, loop continues normally.
         } catch (const BreakException&) {
-            // Break statement was executed, exit the while loop
             break;
         } catch (const ContinueException&) {
-            // Continue statement was executed, skip to next iteration
             continue;
+        } catch (const SuspendException& e) {
+            if (current_coro) {
+                current_coro->block_resume_stack.push_back(1); // 1 means resuming body      
+            }
+            throw;
         }
     }
 

--- a/src/Common/Exceptions.hpp
+++ b/src/Common/Exceptions.hpp
@@ -168,6 +168,22 @@ public:
     }
 };
 
+// Special exception for coroutine suspension - not an error, but control flow
+// This inherits from std::exception directly so it bypasses o2lException catch blocks
+class SuspendException : public std::exception {
+private:
+    std::string reason_;
+
+public:
+    explicit SuspendException(const std::string& reason) : reason_(reason) {}
+    
+    const std::string& getReason() const { return reason_; }
+    
+    const char* what() const noexcept override {
+        return "Coroutine suspended (not an error)";
+    }
+};
+
 // Exception for user-thrown errors via throw statements
 class UserException : public o2lException {
 private:

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -28,6 +28,8 @@
 #include "Common/Exceptions.hpp"
 #include "Runtime/ListInstance.hpp"
 #include "Runtime/ObjectInstance.hpp"
+#include "Runtime/Scheduler.hpp"
+#include "Runtime/ConcurrencyLibrary.hpp"
 #include "Runtime/SystemLibrary.hpp"
 #include "Runtime/FFILibrary.hpp"
 #include "Runtime/CompilerLibrary.hpp"
@@ -36,8 +38,26 @@
 
 namespace o2l {
 
+/**
+ * Helper node to wrap the initial call to Main.main() as a coroutine.
+ */
+class RootCoroutineNode : public ASTNode {
+private:
+    std::shared_ptr<ObjectInstance> main_instance_;
+public:
+    RootCoroutineNode(std::shared_ptr<ObjectInstance> main_instance) 
+        : ASTNode(SourceLocation()), main_instance_(main_instance) {}
+
+    Value evaluate(Context& context) override {
+        std::vector<Value> no_args;
+        return main_instance_->callMethod("main", no_args, context);
+    }
+
+    std::string toString() const override { return "RootCoroutine(Main.main)"; }
+};
+
 Interpreter::Interpreter() {
-    // Initialize global context with built-in objects/methods
+    global_context_.defineVariable("Channel", Value(ConcurrencyLibrary::createChannelClassObject()));
     global_context_.defineVariable("io", Value(SystemLibrary::createIOObject()));
     global_context_.defineVariable("os", Value(SystemLibrary::createOSObject()));
     global_context_.defineVariable("fs", Value(SystemLibrary::createFSObject()));
@@ -47,7 +67,7 @@ Interpreter::Interpreter() {
 }
 
 Interpreter::Interpreter(const std::string& filename) : source_filename_(filename) {
-    // Initialize global context with built-in objects/methods
+    global_context_.defineVariable("Channel", Value(ConcurrencyLibrary::createChannelClassObject()));
     global_context_.defineVariable("io", Value(SystemLibrary::createIOObject()));
     global_context_.defineVariable("os", Value(SystemLibrary::createOSObject()));
     global_context_.defineVariable("fs", Value(SystemLibrary::createFSObject()));
@@ -126,7 +146,7 @@ Value Interpreter::execute(const std::vector<ASTNodePtr>& nodes) {
         throw EvaluationError("Program must contain a 'Main' object as entry point");
     }
 
-    // Second pass: Execute Main.main()
+    // Second pass: Execute Main.main() via Scheduler
     try {
         Value main_object = global_context_.getVariable("Main");
 
@@ -140,9 +160,21 @@ Value Interpreter::execute(const std::vector<ASTNodePtr>& nodes) {
             throw EvaluationError("Main object must have a 'main()' method");
         }
 
-        // Call Main.main() with no arguments
-        std::vector<Value> no_args;
-        return main_instance->callMethod("main", no_args, global_context_);
+        // Initialize scheduler
+        auto& scheduler = Scheduler::instance();
+        scheduler.reset(); // Ensure a clean state
+
+        // Wrap Main.main() call in a RootCoroutineNode
+        auto root_node = std::make_unique<RootCoroutineNode>(main_instance);
+        
+        // Spawn the root coroutine
+        scheduler.spawn(root_node.get(), global_context_);
+
+        // Run the scheduler
+        scheduler.run();
+
+        // Return the result of the root coroutine
+        return scheduler.getRootResult();
 
     } catch (const UnresolvedReferenceError& e) {
         // Re-throw the original error instead of masking it

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -173,6 +173,11 @@ Value Interpreter::execute(const std::vector<ASTNodePtr>& nodes) {
         // Run the scheduler
         scheduler.run();
 
+        // Propagate any exception thrown by the root coroutine
+        if (auto ex = scheduler.getRootException()) {
+            std::rethrow_exception(ex);
+        }
+
         // Return the result of the root coroutine
         return scheduler.getRootResult();
 

--- a/src/Lexer.cpp
+++ b/src/Lexer.cpp
@@ -278,6 +278,7 @@ TokenType Lexer::getKeywordType(const std::string& identifier) const {
     if (identifier == "Result") return TokenType::RESULT;
     if (identifier == "Error") return TokenType::ERROR;
     if (identifier == "null") return TokenType::NULL_TOKEN;
+    if (identifier == "spawn") return TokenType::SPAWN;
 #if O2L_ENABLE_NAMESPACES
     if (identifier == "namespace") return TokenType::NAMESPACE;
 #endif

--- a/src/Lexer.hpp
+++ b/src/Lexer.hpp
@@ -50,6 +50,7 @@ enum class TokenType {
     RESULT,
     ERROR,
     NAMESPACE,
+    SPAWN,
     
     // Modifiers
     AT_EXTERNAL,

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -57,6 +57,7 @@
 #include "AST/SetLiteralNode.hpp"
 #include "AST/NamespaceNode.hpp"
 #include "AST/QualifiedIdentifierNode.hpp"
+#include "AST/SpawnNode.hpp"
 
 namespace o2l {
 
@@ -125,6 +126,8 @@ std::vector<ASTNodePtr> Parser::parse() {
             nodes.push_back(parseRecordDeclaration());
         } else if (currentToken().type == TokenType::PROTOCOL) {
             nodes.push_back(parseProtocolDeclaration());
+        } else if (currentToken().type == TokenType::SPAWN) {
+            nodes.push_back(parseSpawnExpression());
         } else if (currentToken().type == TokenType::NAMESPACE) {
 #if O2L_ENABLE_NAMESPACES
             nodes.push_back(parseNamespaceDeclaration());
@@ -1195,7 +1198,12 @@ ASTNodePtr Parser::parseStatement() {
     if (token.type == TokenType::TRY) {
         return parseTryCatchFinallyStatement();
     }
-    
+
+    // Check for spawn statements
+    if (token.type == TokenType::SPAWN) {
+        return parseSpawnExpression();
+    }
+
     // Check for variable declarations (identifier followed by colon)
     if (token.type == TokenType::IDENTIFIER && peekToken().type == TokenType::COLON) {
         return parseVariableDeclaration();
@@ -2054,6 +2062,31 @@ std::string Parser::reconstructQualifiedName(ASTNode* node) {
         return result;
     }
     return "unknown";
+}
+
+ASTNodePtr Parser::parseSpawnExpression() {
+    Token spawn_token = consume(TokenType::SPAWN, "Expected 'spawn'");
+    SourceLocation location(filename_, spawn_token.line, spawn_token.column);
+
+    consume(TokenType::LBRACE, "Expected '{' after 'spawn'");
+
+    std::vector<ASTNodePtr> body_stmts;
+    while (currentToken().type != TokenType::RBRACE && currentToken().type != TokenType::EOF_TOKEN) {
+        while (match(TokenType::NEWLINE)) {}
+        if (currentToken().type == TokenType::RBRACE) {
+            break;
+        }
+        body_stmts.push_back(parseStatement());
+        if (currentToken().type == TokenType::SEMICOLON) {
+            advance();
+        }
+    }
+    consume(TokenType::RBRACE, "Expected '}' after spawn body");
+
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+    auto spawn_node = std::make_unique<SpawnNode>(std::move(body));
+    spawn_node->setSourceLocation(location);
+    return spawn_node;
 }
 
 } // namespace o2l

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -335,7 +335,14 @@ ASTNodePtr Parser::parsePrimaryExpression() {
     while (currentToken().type == TokenType::DOT) {
         advance(); // consume dot
         
-        Token member_name_token = consume(TokenType::IDENTIFIER, "Expected member name after '.'");
+        // Accept keywords that can be used as method names (e.g. Channel.new())
+        Token member_name_token;
+        if (currentToken().type == TokenType::IDENTIFIER || currentToken().type == TokenType::NEW) {
+            member_name_token = currentToken();
+            advance();
+        } else {
+            throw SyntaxError("Expected member name after '.' at line " + std::to_string(currentToken().line));
+        }
         std::string member_name = member_name_token.value;
         
         // Check if this is a method call (has parentheses)

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -336,13 +336,11 @@ ASTNodePtr Parser::parsePrimaryExpression() {
         advance(); // consume dot
         
         // Accept keywords that can be used as method names (e.g. Channel.new())
-        Token member_name_token;
-        if (currentToken().type == TokenType::IDENTIFIER || currentToken().type == TokenType::NEW) {
-            member_name_token = currentToken();
-            advance();
-        } else {
+        if (currentToken().type != TokenType::IDENTIFIER && currentToken().type != TokenType::NEW) {
             throw SyntaxError("Expected member name after '.' at line " + std::to_string(currentToken().line));
         }
+        Token member_name_token = currentToken();
+        advance();
         std::string member_name = member_name_token.value;
         
         // Check if this is a method call (has parentheses)

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -86,6 +86,7 @@ class Parser {
     ASTNodePtr parseTryCatchFinallyStatement();
     ASTNodePtr parseResultStaticCall();
     ASTNodePtr parseNamespaceDeclaration();
+    ASTNodePtr parseSpawnExpression();
 
     // Helper method to parse type names including generics
     std::string parseTypeName();

--- a/src/Runtime/ChannelInstance.cpp
+++ b/src/Runtime/ChannelInstance.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ChannelInstance.hpp"
+#include "Scheduler.hpp"
+#include "../Common/Exceptions.hpp"
+
+namespace o2l {
+
+ChannelInstance::ChannelInstance(size_t capacity) : capacity_(capacity) {}
+
+void ChannelInstance::send(const Value& value) {
+    if (closed_) {
+        throw EvaluationError("Cannot send on closed channel");
+    }
+
+    auto& scheduler = Scheduler::instance();
+
+    // If we just resumed from a send suspension, we're done
+    if (scheduler.hasResumeValue()) {
+        scheduler.consumeResumeValue();
+        return;
+    }
+
+    // 1. If there's a waiting receiver, hand over the value immediately
+    if (!waiting_receivers_.empty()) {
+        uint64_t receiver_id = waiting_receivers_.front();
+        waiting_receivers_.pop_front();
+        
+        scheduler.resumeCoroutine(receiver_id, value);
+        return;
+    }
+
+    // 2. If it's a buffered channel and has space, buffer it
+    if (capacity_ > 0 && buffer_.size() < capacity_) {
+        buffer_.push_back(value);
+        return;
+    }
+
+    // 3. Otherwise, suspend the sender
+    if (scheduler.isActive()) {
+        uint64_t coro_id = scheduler.currentCoroutine()->id;
+        waiting_senders_.push_back({coro_id, value});
+        
+        scheduler.suspendCurrent("channel_send");
+        // suspendCurrent throws SuspendException, so we never reach here
+    } else {
+        throw EvaluationError("Blocking channel send without active scheduler not supported");
+    }
+}
+
+Value ChannelInstance::receive() {
+    auto& scheduler = Scheduler::instance();
+
+    // If we just resumed from a receive suspension, return the resumed value
+    if (scheduler.hasResumeValue()) {
+        return scheduler.consumeResumeValue();
+    }
+
+    // 1. If there's data in the buffer, take it
+    if (!buffer_.empty()) {
+        Value value = buffer_.front();
+        buffer_.pop_front();
+        
+        // If there are waiting senders, move one into the buffer
+        if (!waiting_senders_.empty()) {
+            auto sender = waiting_senders_.front();
+            waiting_senders_.pop_front();
+            
+            buffer_.push_back(sender.value);
+            scheduler.resumeCoroutine(sender.coroutine_id, Value(Int(0)));
+        }
+        
+        return value;
+    }
+
+    // 2. If it's unbuffered and there's a waiting sender, take their value
+    if (capacity_ == 0 && !waiting_senders_.empty()) {
+        auto sender = waiting_senders_.front();
+        waiting_senders_.pop_front();
+        
+        Value value = sender.value;
+        scheduler.resumeCoroutine(sender.coroutine_id, Value(Int(0)));
+        return value;
+    }
+
+    // 3. If closed and empty, error
+    if (closed_) {
+        throw EvaluationError("Cannot receive from closed empty channel");
+    }
+
+    // 4. Otherwise, suspend the receiver
+    if (scheduler.isActive()) {
+        uint64_t coro_id = scheduler.currentCoroutine()->id;
+        waiting_receivers_.push_back(coro_id);
+        
+        scheduler.suspendCurrent("channel_receive");
+        // suspendCurrent throws SuspendException, so we never reach here
+    } else {
+        throw EvaluationError("Blocking channel receive without active scheduler not supported");
+    }
+
+    return Value(Int(0)); // Unreachable
+}
+
+void ChannelInstance::close() {
+    if (closed_) return;
+    closed_ = true;
+
+    auto& scheduler = Scheduler::instance();
+
+    // Wake all waiting receivers with an error (or they might need a sentinel value)
+    // For now, let's just wake them; they will re-check closed_ and throw if buffer empty
+    while (!waiting_receivers_.empty()) {
+        uint64_t receiver_id = waiting_receivers_.front();
+        waiting_receivers_.pop_front();
+        scheduler.resumeCoroutine(receiver_id, Value(Int(0)));
+    }
+
+    // Wake all waiting senders with an error
+    while (!waiting_senders_.empty()) {
+        auto sender = waiting_senders_.front();
+        waiting_senders_.pop_front();
+        // We might want to resume them with an exception or just let them throw on next attempt
+        scheduler.resumeCoroutine(sender.coroutine_id, Value(Int(0)));
+    }
+}
+
+} // namespace o2l

--- a/src/Runtime/ChannelInstance.hpp
+++ b/src/Runtime/ChannelInstance.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include "Value.hpp"
+
+namespace o2l {
+
+class ChannelInstance {
+public:
+    explicit ChannelInstance(size_t capacity = 0);
+    virtual ~ChannelInstance() = default;
+
+    void send(const Value& value);
+    Value receive();
+    void close();
+    bool isOpen() const { return !closed_; }
+    size_t getCapacity() const { return capacity_; }
+
+private:
+    size_t capacity_;
+    bool closed_ = false;
+    std::deque<Value> buffer_;
+    
+    // Coroutines waiting to send (for unbuffered or full buffered channels)
+    struct WaitingSender {
+        uint64_t coroutine_id;
+        Value value;
+    };
+    std::deque<WaitingSender> waiting_senders_;
+    
+    // Coroutines waiting to receive (when buffer is empty)
+    std::deque<uint64_t> waiting_receivers_;
+};
+
+} // namespace o2l

--- a/src/Runtime/ConcurrencyLibrary.cpp
+++ b/src/Runtime/ConcurrencyLibrary.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConcurrencyLibrary.hpp"
+#include "ObjectInstance.hpp"
+#include "ChannelInstance.hpp"
+#include "Scheduler.hpp"
+#include "../Common/Exceptions.hpp"
+#include <thread>
+#include <chrono>
+
+namespace o2l {
+
+std::shared_ptr<ObjectInstance> ConcurrencyLibrary::createConcurrencyObject() {
+    auto obj = std::make_shared<ObjectInstance>("concurrency");
+    
+    obj->addMethod("sleep", nativeSleep, true);
+    obj->addMethod("Channel", [](const std::vector<Value>&, Context&) {
+        return Value(createChannelClassObject());
+    }, true);
+
+    return obj;
+}
+
+std::shared_ptr<ObjectInstance> ConcurrencyLibrary::createChannelClassObject() {
+    auto obj = std::make_shared<ObjectInstance>("ChannelClass");
+    obj->addMethod("new", nativeChannelNew, true);
+    return obj;
+}
+
+Value ConcurrencyLibrary::nativeSleep(const std::vector<Value>& args, Context& context) {
+    if (args.size() != 1 || !std::holds_alternative<Int>(args[0])) {
+        throw EvaluationError("sleep() requires one Integer argument (milliseconds)");
+    }
+
+    Int ms = std::get<Int>(args[0]);
+    auto& scheduler = Scheduler::instance();
+
+    if (scheduler.isActive()) {
+        if (scheduler.hasResumeValue()) {
+            scheduler.consumeResumeValue();
+            return Value(Int(0));
+        }
+        scheduler.suspendForSleep(static_cast<uint64_t>(ms));
+    } else {
+        std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    }
+
+    return Value(Int(0));
+}
+
+Value ConcurrencyLibrary::nativeChannelNew(const std::vector<Value>& args, Context& context) {
+    size_t capacity = 0;
+    if (args.size() >= 1 && std::holds_alternative<Int>(args[0])) {
+        capacity = static_cast<size_t>(std::get<Int>(args[0]));
+    }
+
+    auto channel = std::make_shared<ChannelInstance>(capacity);
+    auto channel_obj = std::make_shared<ObjectInstance>("Channel");
+    
+    channel_obj->addMethod("send", [channel](const std::vector<Value>& args, Context&) {
+        if (args.size() != 1) throw EvaluationError("send() requires 1 argument");
+        channel->send(args[0]);
+        return Value(Int(0));
+    }, true);
+
+    channel_obj->addMethod("receive", [channel](const std::vector<Value>&, Context&) {
+        return channel->receive();
+    }, true);
+
+    channel_obj->addMethod("close", [channel](const std::vector<Value>&, Context&) {
+        channel->close();
+        return Value(Int(0));
+    }, true);
+
+    channel_obj->addMethod("isOpen", [channel](const std::vector<Value>&, Context&) {
+        return Value(channel->isOpen());
+    }, true);
+
+    return Value(channel_obj);
+}
+
+} // namespace o2l

--- a/src/Runtime/ConcurrencyLibrary.hpp
+++ b/src/Runtime/ConcurrencyLibrary.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "Value.hpp"
+
+namespace o2l {
+
+class ObjectInstance;
+class Context;
+
+class ConcurrencyLibrary {
+public:
+    static std::shared_ptr<ObjectInstance> createConcurrencyObject();
+    static std::shared_ptr<ObjectInstance> createChannelClassObject();
+
+    // Native methods
+    static Value nativeSleep(const std::vector<Value>& args, Context& context);
+    static Value nativeChannelNew(const std::vector<Value>& args, Context& context);
+    static Value nativeChannelSend(const std::vector<Value>& args, Context& context);
+    static Value nativeChannelReceive(const std::vector<Value>& args, Context& context);
+    static Value nativeChannelClose(const std::vector<Value>& args, Context& context);
+    static Value nativeChannelIsOpen(const std::vector<Value>& args, Context& context);
+};
+
+} // namespace o2l

--- a/src/Runtime/Context.cpp
+++ b/src/Runtime/Context.cpp
@@ -211,4 +211,22 @@ std::vector<std::string> Context::getVariableNames() const {
     return names;
 }
 
+Context Context::clone() const {
+    Context cloned;
+    // Context constructor already calls pushScope(), so we need to clear it
+    cloned.scopes_.clear();
+    cloned.const_scopes_.clear();
+
+    // Deep copy scope stack (each scope is a map<string, Value>)
+    cloned.scopes_ = this->scopes_;
+    cloned.const_scopes_ = this->const_scopes_;
+
+    // Fresh call stacks for the new coroutine
+    cloned.call_stack_ = {};
+    cloned.execution_stack_ = {};
+    cloned.this_stack_ = {};
+
+    return cloned;
+}
+
 }  // namespace o2l

--- a/src/Runtime/Context.cpp
+++ b/src/Runtime/Context.cpp
@@ -224,7 +224,8 @@ Context Context::clone() const {
     // Fresh call stacks for the new coroutine
     cloned.call_stack_ = {};
     cloned.execution_stack_ = {};
-    cloned.this_stack_ = {};
+    // Preserve 'this' so spawn blocks inside object methods can call this.method()
+    cloned.this_stack_ = this->this_stack_;
 
     return cloned;
 }

--- a/src/Runtime/Context.hpp
+++ b/src/Runtime/Context.hpp
@@ -117,6 +117,9 @@ class Context {
     void popThisObject();
     std::shared_ptr<ObjectInstance> getThisObject() const;
     bool hasThisObject() const;
+
+    // Concurrency support: clone context for new coroutine
+    Context clone() const;
 };
 
 }  // namespace o2l

--- a/src/Runtime/Coroutine.cpp
+++ b/src/Runtime/Coroutine.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Coroutine.hpp"
+
+namespace o2l {
+
+Coroutine::Coroutine(uint64_t id, ASTNode* body, Context context)
+    : id(id), state(State::Ready), context(std::move(context)), body(body), result(Int(0)) {}
+
+} // namespace o2l

--- a/src/Runtime/Coroutine.hpp
+++ b/src/Runtime/Coroutine.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <chrono>
+#include <vector>
+#include "Context.hpp"
+#include "../AST/Node.hpp"
+
+namespace o2l {
+
+struct Coroutine {
+    enum class State { Ready, Running, Suspended, Completed, Failed };
+
+    uint64_t id;
+    State state;
+    Context context;
+    ASTNode* body; // Raw pointer: AST is owned by the parser output/Main nodes
+    
+    Value resume_value;
+    bool has_resume_value = false;
+    std::string suspend_reason;
+    std::chrono::steady_clock::time_point wake_time;
+    
+    // Progress tracking for statement-level resumption
+    std::vector<size_t> block_resume_stack;
+    
+    Value result;
+    std::string error_message;
+
+    Coroutine(uint64_t id, ASTNode* body, Context context);
+};
+
+} // namespace o2l

--- a/src/Runtime/CoroutineHandle.hpp
+++ b/src/Runtime/CoroutineHandle.hpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace o2l {
+
+class CoroutineHandle {
+private:
+    uint64_t coroutine_id_;
+
+public:
+    explicit CoroutineHandle(uint64_t id) : coroutine_id_(id) {}
+    uint64_t getId() const { return coroutine_id_; }
+};
+
+} // namespace o2l

--- a/src/Runtime/HttpClientLibrary.cpp
+++ b/src/Runtime/HttpClientLibrary.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "HttpClientLibrary.hpp"
+#include "Scheduler.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -331,8 +332,7 @@ Value HttpClientLibrary::nativeGet(const std::vector<Value>& args, Context& cont
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativePost(const std::vector<Value>& args, Context& context) {
@@ -373,8 +373,7 @@ Value HttpClientLibrary::nativePost(const std::vector<Value>& args, Context& con
         request.headers["Content-Type"] = "application/json";
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativePut(const std::vector<Value>& args, Context& context) {
@@ -399,8 +398,7 @@ Value HttpClientLibrary::nativePut(const std::vector<Value>& args, Context& cont
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativeDelete(const std::vector<Value>& args, Context& context) {
@@ -421,8 +419,7 @@ Value HttpClientLibrary::nativeDelete(const std::vector<Value>& args, Context& c
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativePatch(const std::vector<Value>& args, Context& context) {
@@ -447,8 +444,7 @@ Value HttpClientLibrary::nativePatch(const std::vector<Value>& args, Context& co
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativeHead(const std::vector<Value>& args, Context& context) {
@@ -469,8 +465,7 @@ Value HttpClientLibrary::nativeHead(const std::vector<Value>& args, Context& con
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativeOptions(const std::vector<Value>& args, Context& context) {
@@ -491,8 +486,7 @@ Value HttpClientLibrary::nativeOptions(const std::vector<Value>& args, Context& 
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 // Advanced Request Methods
@@ -519,8 +513,7 @@ Value HttpClientLibrary::nativeRequest(const std::vector<Value>& args, Context& 
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 Value HttpClientLibrary::nativeRequestWithConfig(const std::vector<Value>& args, Context& context) {
@@ -574,8 +567,7 @@ Value HttpClientLibrary::nativeRequestWithConfig(const std::vector<Value>& args,
         }
     }
 
-    HttpResponse response = executeHttpRequest(request);
-    return Value(createResponseObject(response));
+    return yieldForHttpRequest(request);
 }
 
 // Request Configuration Methods
@@ -1965,5 +1957,32 @@ bool HttpClientLibrary::validateUrl(const std::string& url) {
 bool HttpClientLibrary::validateTimeout(int timeout) {
     return timeout > 0 && timeout <= 300;  // Max 5 minutes
 }
+
+Value HttpClientLibrary::yieldForHttpRequest(const HttpRequest& request) {
+    auto& sched = Scheduler::instance();
+    if (sched.isActive() && sched.currentCoroutine()) {
+        auto* coro = sched.currentCoroutine();
+        if (coro->suspend_reason == "io" && sched.hasResumeValue()) {
+            // Resuming: return the pre-fetched result
+            Value result = sched.consumeResumeValue();
+            coro->suspend_reason = "";
+            return result;
+        }
+
+        // First call: dispatch and suspend
+        sched.suspendForIO([request]() -> Value {
+            HttpResponse resp = HttpClientLibrary::executeHttpRequest(request);
+            return Value(HttpClientLibrary::createResponseObject(resp));
+        });
+
+        // unreachable
+        return Value(Int(0));
+    }
+
+    // No scheduler: synchronous fallback
+    HttpResponse resp = HttpClientLibrary::executeHttpRequest(request);
+    return Value(HttpClientLibrary::createResponseObject(resp));
+}
+
 
 }  // namespace o2l

--- a/src/Runtime/HttpClientLibrary.hpp
+++ b/src/Runtime/HttpClientLibrary.hpp
@@ -110,6 +110,7 @@ class HttpClientLibrary {
    private:
     // Core HTTP execution
     static HttpResponse executeHttpRequest(const HttpRequest& request);
+    static Value yieldForHttpRequest(const HttpRequest& request);
 
     // Helper methods
     static std::string buildQueryString(const std::map<std::string, std::string>& params);

--- a/src/Runtime/HttpServerLibrary.cpp
+++ b/src/Runtime/HttpServerLibrary.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "HttpServerLibrary.hpp"
+#include "Scheduler.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -1501,6 +1502,14 @@ Value HttpServerLibrary::nativeWaitForever(const std::vector<Value>& args, Conte
     auto server = getServerFromValue(args[0]);
     if (!server) {
         throw std::runtime_error("Invalid server instance");
+    }
+
+    auto& sched = Scheduler::instance();
+    if (sched.isActive() && sched.currentCoroutine()) {
+        // Suspend indefinitely (will be woken by program exit)
+        sched.suspendForSleep((std::numeric_limits<uint64_t>::max)());
+        // unreachable
+        return Value(Text("Server stopped"));
     }
 
     // Block until server is stopped

--- a/src/Runtime/IOThreadPool.cpp
+++ b/src/Runtime/IOThreadPool.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "IOThreadPool.hpp"
+#include "Scheduler.hpp"
+
+namespace o2l {
+
+IOThreadPool& IOThreadPool::instance() {
+    static IOThreadPool instance;
+    return instance;
+}
+
+IOThreadPool::IOThreadPool(size_t threads) {
+    for (size_t i = 0; i < threads; ++i) {
+        workers_.emplace_back([this] { workerThread(); });
+    }
+}
+
+IOThreadPool::~IOThreadPool() {
+    shutdown();
+}
+
+void IOThreadPool::submit(std::function<Value()> work, uint64_t coroutine_id) {
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (stop_) return;
+        tasks_.emplace(std::move(work), coroutine_id);
+    }
+    condition_.notify_one();
+}
+
+void IOThreadPool::shutdown() {
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (stop_) return;
+        stop_ = true;
+    }
+    condition_.notify_all();
+    for (std::thread& worker : workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+    workers_.clear();
+}
+
+void IOThreadPool::workerThread() {
+    while (true) {
+        std::pair<std::function<Value()>, uint64_t> task;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            condition_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+            if (stop_ && tasks_.empty()) return;
+            task = std::move(tasks_.front());
+            tasks_.pop();
+        }
+
+        // Execute the work
+        Value result = task.first();
+
+        // Enqueue completion to scheduler
+        Scheduler::instance().enqueueReady(task.second, result);
+    }
+}
+
+} // namespace o2l

--- a/src/Runtime/IOThreadPool.hpp
+++ b/src/Runtime/IOThreadPool.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+#include "Value.hpp"
+
+namespace o2l {
+
+class IOThreadPool {
+public:
+    static IOThreadPool& instance();
+
+    void submit(std::function<Value()> work, uint64_t coroutine_id);
+    void shutdown();
+
+private:
+    IOThreadPool(size_t threads = 4);
+    ~IOThreadPool();
+
+    std::vector<std::thread> workers_;
+    std::queue<std::pair<std::function<Value()>, uint64_t>> tasks_;
+
+    std::mutex queue_mutex_;
+    std::condition_variable condition_;
+    bool stop_ = false;
+
+    void workerThread();
+};
+
+} // namespace o2l

--- a/src/Runtime/ModuleLoader.cpp
+++ b/src/Runtime/ModuleLoader.cpp
@@ -25,6 +25,7 @@
 #include "../Interpreter.hpp"
 #include "../Lexer.hpp"
 #include "../Parser.hpp"
+#include "ConcurrencyLibrary.hpp"
 #include "DateTimeLibrary.hpp"
 #include "HttpClientLibrary.hpp"
 #include "HttpServerLibrary.hpp"
@@ -458,6 +459,22 @@ bool ModuleLoader::isNativeSystemModule(const ImportPath& import_path) {
         return true;
     }
 
+    // Check if this is a direct concurrency import
+    if (import_path.package_path.empty() && import_path.object_name == "concurrency") {
+        return true;
+    }
+
+    // Check if this is an io import
+    if (import_path.package_path.empty() && import_path.object_name == "io") {
+        return true;
+    }
+
+    // Check if this is a system.io import
+    if (import_path.package_path.size() == 1 && import_path.package_path[0] == "system" &&
+        import_path.object_name == "io") {
+        return true;
+    }
+
     // Check if this is an http.client import
     if (import_path.package_path.size() == 1 && import_path.package_path[0] == "http" &&
         import_path.object_name == "client") {
@@ -500,6 +517,10 @@ std::shared_ptr<ObjectInstance> ModuleLoader::createNativeSystemModule(
         return UrlLibrary::createUrlObject();
     } else if (module_name == "json") {
         return JsonLibrary::createJsonObject();
+    } else if (module_name == "concurrency") {
+        return ConcurrencyLibrary::createConcurrencyObject();
+    } else if (module_name == "io") {
+        return SystemLibrary::createIOObject();
     } else if (module_name == "client") {
         return HttpClientLibrary::createHttpClientObject();
     } else if (module_name == "server") {

--- a/src/Runtime/Scheduler.cpp
+++ b/src/Runtime/Scheduler.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Scheduler.hpp"
+#include "IOThreadPool.hpp"
+#include "../Common/Exceptions.hpp"
+#include <iostream>
+#include <thread>
+#include <algorithm>
+
+namespace o2l {
+
+Scheduler& Scheduler::instance() {
+    static Scheduler instance;
+    return instance;
+}
+
+uint64_t Scheduler::spawn(ASTNode* body, Context cloned_context) {
+    uint64_t id = next_id_++;
+    auto coro = std::make_unique<Coroutine>(id, body, std::move(cloned_context));
+    ready_queue_.push_back(std::move(coro));
+    return id;
+}
+
+void Scheduler::reset() {
+    ready_queue_.clear();
+    timer_queue_.clear();
+    suspended_.clear();
+    {
+        std::unique_lock<std::mutex> lock(completion_mutex_);
+        io_completed_.clear();
+    }
+    running_coro_.reset();
+    current_ = nullptr;
+    next_id_ = 0;
+    active_ = false;
+    root_result_ = Int(0);
+}
+
+void Scheduler::run() {
+    active_ = true;
+    while (!ready_queue_.empty() || !timer_queue_.empty() || !suspended_.empty()) {
+        wakeTimers();
+        processCompletions();
+        
+        if (ready_queue_.empty()) {
+            if (!timer_queue_.empty() || !suspended_.empty()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                continue;
+            }
+            break;
+        }
+
+        running_coro_ = std::move(ready_queue_.front());
+        ready_queue_.pop_front();
+        
+        current_ = running_coro_.get();
+        current_->state = Coroutine::State::Running;
+
+        try {
+            Value result = current_->body->evaluate(current_->context);
+            current_->state = Coroutine::State::Completed;
+            current_->result = result;
+            if (current_->id == 0) {
+                root_result_ = result;
+            }
+            running_coro_.reset();
+            current_ = nullptr;
+        } catch (const SuspendException& e) {
+            // Coroutine was moved to another queue by the suspend method
+            // which reset running_coro_ and current_
+        } catch (const std::exception& e) {
+            current_->state = Coroutine::State::Failed;
+            current_->error_message = e.what();
+            std::cerr << "Error in coroutine #" << current_->id << ": " << e.what() << std::endl;
+            running_coro_.reset();
+            current_ = nullptr;
+        }
+    }
+    active_ = false;
+}
+
+void Scheduler::yield() {
+    if (!running_coro_) return;
+    
+    running_coro_->state = Coroutine::State::Ready;
+    running_coro_->has_resume_value = true;
+    running_coro_->resume_value = Int(0);
+    
+    ready_queue_.push_back(std::move(running_coro_));
+    current_ = nullptr;
+    throw SuspendException("yield");
+}
+
+void Scheduler::suspendForSleep(uint64_t ms) {
+    if (!running_coro_) return;
+    
+    running_coro_->state = Coroutine::State::Suspended;
+    running_coro_->suspend_reason = "sleep";
+    running_coro_->wake_time = std::chrono::steady_clock::now() + std::chrono::milliseconds(ms);
+    running_coro_->has_resume_value = true;
+    running_coro_->resume_value = Int(0);
+    
+    timer_queue_.push_back(std::move(running_coro_));
+    current_ = nullptr;
+    throw SuspendException("sleep");
+}
+
+void Scheduler::suspendCurrent(const std::string& reason) {
+    if (!running_coro_) return;
+
+    uint64_t id = running_coro_->id;
+    running_coro_->state = Coroutine::State::Suspended;
+    running_coro_->suspend_reason = reason;
+
+    suspended_[id] = std::move(running_coro_);
+    current_ = nullptr;
+    throw SuspendException(reason);
+}
+
+void Scheduler::suspendForIO(std::function<Value()> work) {
+    if (!running_coro_) return;
+
+    uint64_t id = running_coro_->id;
+    running_coro_->state = Coroutine::State::Suspended;
+    running_coro_->suspend_reason = "io";
+
+    suspended_[id] = std::move(running_coro_);
+    current_ = nullptr;
+
+    IOThreadPool::instance().submit(std::move(work), id);
+
+    throw SuspendException("io");
+}
+
+void Scheduler::resumeCoroutine(uint64_t id, Value resume_value) {
+    auto it = suspended_.find(id);
+    if (it != suspended_.end()) {
+        auto coro = std::move(it->second);
+        suspended_.erase(it);
+        
+        coro->state = Coroutine::State::Ready;
+        coro->resume_value = resume_value;
+        coro->has_resume_value = true;
+        ready_queue_.push_back(std::move(coro));
+    }
+}
+
+void Scheduler::enqueueReady(uint64_t id, Value result) {
+    std::unique_lock<std::mutex> lock(completion_mutex_);
+    io_completed_.emplace_back(id, result);
+}
+
+bool Scheduler::hasResumeValue() const {
+    return current_ && current_->has_resume_value;
+}
+
+Value Scheduler::consumeResumeValue() {
+    if (!current_ || !current_->has_resume_value) {
+        return Int(0);
+    }
+    Value val = current_->resume_value;
+    current_->resume_value = Int(0);
+    current_->has_resume_value = false;
+    return val;
+}
+
+Value Scheduler::getRootResult() const {
+    return root_result_;
+}
+
+void Scheduler::wakeTimers() {
+    auto now = std::chrono::steady_clock::now();
+    for (auto it = timer_queue_.begin(); it != timer_queue_.end(); ) {
+        if ((*it)->wake_time <= now) {
+            auto coro = std::move(*it);
+            coro->state = Coroutine::State::Ready;
+            ready_queue_.push_back(std::move(coro));
+            it = timer_queue_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void Scheduler::processCompletions() {
+    std::deque<std::pair<uint64_t, Value>> completions;
+    {
+        std::unique_lock<std::mutex> lock(completion_mutex_);
+        completions = std::move(io_completed_);
+    }
+
+    for (const auto& comp : completions) {
+        resumeCoroutine(comp.first, comp.second);
+    }
+}
+
+} // namespace o2l

--- a/src/Runtime/Scheduler.cpp
+++ b/src/Runtime/Scheduler.cpp
@@ -99,11 +99,10 @@ void Scheduler::run() {
 
 void Scheduler::yield() {
     if (!running_coro_) return;
-    
+
     running_coro_->state = Coroutine::State::Ready;
     running_coro_->has_resume_value = true;
     running_coro_->resume_value = Int(0);
-    
     ready_queue_.push_back(std::move(running_coro_));
     current_ = nullptr;
     throw SuspendException("yield");

--- a/src/Runtime/Scheduler.cpp
+++ b/src/Runtime/Scheduler.cpp
@@ -48,6 +48,7 @@ void Scheduler::reset() {
     next_id_ = 0;
     active_ = false;
     root_result_ = Int(0);
+    root_exception_ = nullptr;
 }
 
 void Scheduler::run() {
@@ -85,6 +86,9 @@ void Scheduler::run() {
         } catch (const std::exception& e) {
             current_->state = Coroutine::State::Failed;
             current_->error_message = e.what();
+            if (current_->id == 0) {
+                root_exception_ = std::current_exception();
+            }
             std::cerr << "Error in coroutine #" << current_->id << ": " << e.what() << std::endl;
             running_coro_.reset();
             current_ = nullptr;

--- a/src/Runtime/Scheduler.hpp
+++ b/src/Runtime/Scheduler.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <functional>
 #include <mutex>
+#include <exception>
 #include "Coroutine.hpp"
 
 namespace o2l {
@@ -52,8 +53,9 @@ public:
     bool isActive() const { return active_; }
     Coroutine* currentCoroutine() { return current_; }
     
-    // Root result (from the first coroutine spawned, usually Main)
+    // Root result and exception (from the first coroutine spawned, usually Main)
     Value getRootResult() const;
+    std::exception_ptr getRootException() const { return root_exception_; }
 
 private:
     Scheduler() = default;
@@ -71,6 +73,7 @@ private:
     uint64_t next_id_ = 0;
     bool active_ = false;
     Value root_result_ = Int(0);
+    std::exception_ptr root_exception_;
 
     void wakeTimers();
     void processCompletions();

--- a/src/Runtime/Scheduler.hpp
+++ b/src/Runtime/Scheduler.hpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <deque>
+#include <map>
+#include <memory>
+#include <vector>
+#include <functional>
+#include <mutex>
+#include "Coroutine.hpp"
+
+namespace o2l {
+
+class Scheduler {
+public:
+    static Scheduler& instance();
+
+    // Core lifecycle
+    uint64_t spawn(ASTNode* body, Context cloned_context);
+    void run(); // Main loop
+    void reset(); // Clear state
+    
+    // Suspend operations (throw SuspendException)
+    void yield();
+    void suspendForSleep(uint64_t ms);
+    void suspendCurrent(const std::string& reason);
+    void suspendForIO(std::function<Value()> work);
+    
+    // Resume operations (thread-safe)
+    void resumeCoroutine(uint64_t id, Value resume_value = Int(0));
+    void enqueueReady(uint64_t id, Value result);
+
+    bool hasResumeValue() const;
+    Value consumeResumeValue();
+    
+    // State queries
+    bool isActive() const { return active_; }
+    Coroutine* currentCoroutine() { return current_; }
+    
+    // Root result (from the first coroutine spawned, usually Main)
+    Value getRootResult() const;
+
+private:
+    Scheduler() = default;
+    
+    std::deque<std::unique_ptr<Coroutine>> ready_queue_;
+    std::vector<std::unique_ptr<Coroutine>> timer_queue_;
+    std::map<uint64_t, std::unique_ptr<Coroutine>> suspended_;
+    
+    // Thread-safe completion queue
+    std::mutex completion_mutex_;
+    std::deque<std::pair<uint64_t, Value>> io_completed_;
+
+    std::unique_ptr<Coroutine> running_coro_;
+    Coroutine* current_ = nullptr;
+    uint64_t next_id_ = 0;
+    bool active_ = false;
+    Value root_result_ = Int(0);
+
+    void wakeTimers();
+    void processCompletions();
+    void scheduleNext();
+};
+
+} // namespace o2l

--- a/src/Runtime/SystemLibrary.cpp
+++ b/src/Runtime/SystemLibrary.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "SystemLibrary.hpp"
+#include "Scheduler.hpp"
 
 #include <array>
 #include <cstdlib>
@@ -414,6 +415,24 @@ Value SystemLibrary::nativeInput(const std::vector<Value>& args, Context& contex
         }
         std::string prompt = std::get<Text>(args[0]);
         std::cout << prompt;
+    }
+
+    auto& sched = Scheduler::instance();
+    if (sched.isActive() && sched.currentCoroutine()) {
+        auto* coro = sched.currentCoroutine();
+        if (coro->suspend_reason == "io" && sched.hasResumeValue()) {
+            Value result = sched.consumeResumeValue();
+            coro->suspend_reason = "";
+            return result;
+        }
+
+        sched.suspendForIO([]() -> Value {
+            std::string input_line;
+            std::getline(std::cin, input_line);
+            return Value(Text(input_line));
+        });
+        // unreachable
+        return Value(Text(""));
     }
 
     // Read line from stdin
@@ -1460,6 +1479,23 @@ Value SystemLibrary::nativeExecute(const std::vector<Value>& args, Context& cont
     }
 
     std::string command = std::get<Text>(args[0]);
+
+    auto& sched = Scheduler::instance();
+    if (sched.isActive() && sched.currentCoroutine()) {
+        auto* coro = sched.currentCoroutine();
+        if (coro->suspend_reason == "io" && sched.hasResumeValue()) {
+            Value result = sched.consumeResumeValue();
+            coro->suspend_reason = "";
+            return result;
+        }
+
+        sched.suspendForIO([command]() -> Value {
+            int exit_code = std::system(command.c_str());
+            return Value(Int(exit_code));
+        });
+        // unreachable
+        return Value(Int(0));
+    }
 
     try {
         int exit_code = std::system(command.c_str());

--- a/src/Runtime/Value.cpp
+++ b/src/Runtime/Value.cpp
@@ -31,6 +31,7 @@
 #include "RecordType.hpp"
 #include "RepeatIterator.hpp"
 #include "ResultInstance.hpp"
+#include "CoroutineHandle.hpp"
 #include "SetInstance.hpp"
 #include "SetIterator.hpp"
 #include "FFI/FFITypes.hpp"
@@ -112,6 +113,10 @@ std::string valueToString(const Value& value) {
                 return v->toString();
             } else if constexpr (std::is_same_v<T, std::shared_ptr<ResultInstance>>) {
                 return v->toString();
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<CoroutineHandle>>) {
+                return "Coroutine(" + std::to_string(v->getId()) + ")";
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<ChannelInstance>>) {
+                return "Channel";
             } else if constexpr (std::is_same_v<T, std::shared_ptr<ffi::PtrInstance>>) {
                 return v->toString();
             } else if constexpr (std::is_same_v<T, std::shared_ptr<ffi::CBufferInstance>>) {
@@ -178,6 +183,10 @@ std::string getTypeName(const Value& value) {
                 return "Error";
             } else if constexpr (std::is_same_v<T, std::shared_ptr<ResultInstance>>) {
                 return "Result<" + v->getValueTypeName() + ", " + v->getErrorTypeName() + ">";
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<CoroutineHandle>>) {
+                return "Coroutine";
+            } else if constexpr (std::is_same_v<T, std::shared_ptr<ChannelInstance>>) {
+                return "Channel";
             } else if constexpr (std::is_same_v<T, std::shared_ptr<ffi::PtrInstance>>) {
                 return "Ptr<Void>";
             } else if constexpr (std::is_same_v<T, std::shared_ptr<ffi::CBufferInstance>>) {
@@ -236,6 +245,10 @@ bool valuesEqual(const Value& a, const Value& b) {
                     return lhs.get() == rhs.get();  // Pointer equality for error instances
                 } else if constexpr (std::is_same_v<T, std::shared_ptr<ResultInstance>>) {
                     return lhs.get() == rhs.get();  // Pointer equality for result instances
+                } else if constexpr (std::is_same_v<T, std::shared_ptr<CoroutineHandle>>) {
+                    return lhs->getId() == rhs->getId();
+                } else if constexpr (std::is_same_v<T, std::shared_ptr<ChannelInstance>>) {
+                    return lhs.get() == rhs.get();
                 } else {
                     return lhs == rhs;
                 }

--- a/src/Runtime/Value.hpp
+++ b/src/Runtime/Value.hpp
@@ -41,6 +41,8 @@ class SetInstance;
 class SetIterator;
 class ErrorInstance;
 class ResultInstance;
+class CoroutineHandle;
+class ChannelInstance;
 
 // FFI forward declarations
 namespace ffi {
@@ -49,7 +51,7 @@ class CBufferInstance;
 class CStructInstance;
 class CArrayInstance;
 class CCallbackInstance;
-}
+}  // namespace ffi
 
 // Built-in immutable types
 using Text = std::string;
@@ -92,56 +94,55 @@ using ValueList = List<std::shared_ptr<Value>>;
 using ValueMap = Map<std::shared_ptr<Value>, std::shared_ptr<Value>>;
 using ValueOptional = Optional<std::shared_ptr<Value>>;
 
+#if O2L_HAS_INT128
+using ValueVariantBase = std::variant<
+    Int, Long, Float, Double, Text, Bool, Char, std::shared_ptr<ObjectInstance>,
+    std::shared_ptr<EnumInstance>, std::shared_ptr<RecordType>,
+    std::shared_ptr<RecordInstance>, std::shared_ptr<ProtocolInstance>,
+    std::shared_ptr<ListInstance>, std::shared_ptr<ListIterator>,
+    std::shared_ptr<RepeatIterator>, std::shared_ptr<MapInstance>,
+    std::shared_ptr<MapIterator>, std::shared_ptr<MapObject>,
+    std::shared_ptr<SetInstance>, std::shared_ptr<SetIterator>,
+    std::shared_ptr<ErrorInstance>, std::shared_ptr<ResultInstance>,
+    std::shared_ptr<CoroutineHandle>, std::shared_ptr<ChannelInstance>,
+    std::shared_ptr<ffi::PtrInstance>, std::shared_ptr<ffi::CBufferInstance>,
+    std::shared_ptr<ffi::CStructInstance>, std::shared_ptr<ffi::CArrayInstance>,
+    std::shared_ptr<ffi::CCallbackInstance>, ValueList, ValueMap, ValueOptional>;
+#else
+using ValueVariantBase = std::variant<
+    Int, Float, Double, Text, Bool, Char, std::shared_ptr<ObjectInstance>,
+    std::shared_ptr<EnumInstance>, std::shared_ptr<RecordType>,
+    std::shared_ptr<RecordInstance>, std::shared_ptr<ProtocolInstance>,
+    std::shared_ptr<ListInstance>, std::shared_ptr<ListIterator>,
+    std::shared_ptr<RepeatIterator>, std::shared_ptr<MapInstance>,
+    std::shared_ptr<MapIterator>, std::shared_ptr<MapObject>,
+    std::shared_ptr<SetInstance>, std::shared_ptr<SetIterator>,
+    std::shared_ptr<ErrorInstance>, std::shared_ptr<ResultInstance>,
+    std::shared_ptr<CoroutineHandle>, std::shared_ptr<ChannelInstance>,
+    std::shared_ptr<ffi::PtrInstance>, std::shared_ptr<ffi::CBufferInstance>,
+    std::shared_ptr<ffi::CStructInstance>, std::shared_ptr<ffi::CArrayInstance>,
+    std::shared_ptr<ffi::CCallbackInstance>, ValueList, ValueMap, ValueOptional>;
+#endif
+
 // The main Value variant that represents all possible O²L values
-struct Value
-    : public std::variant<Int, 
-#if O2L_HAS_INT128
-                          Long,
-#endif
-                          Float, Double, Text, Bool, Char,
-                          std::shared_ptr<ObjectInstance>, std::shared_ptr<EnumInstance>,
-                          std::shared_ptr<RecordType>, std::shared_ptr<RecordInstance>,
-                          std::shared_ptr<ProtocolInstance>, std::shared_ptr<ListInstance>,
-                          std::shared_ptr<ListIterator>, std::shared_ptr<RepeatIterator>,
-                          std::shared_ptr<MapInstance>, std::shared_ptr<MapIterator>,
-                          std::shared_ptr<MapObject>, std::shared_ptr<SetInstance>,
-                          std::shared_ptr<SetIterator>, std::shared_ptr<ErrorInstance>,
-                          std::shared_ptr<ResultInstance>, std::shared_ptr<ffi::PtrInstance>,
-                          std::shared_ptr<ffi::CBufferInstance>, std::shared_ptr<ffi::CStructInstance>,
-                          std::shared_ptr<ffi::CArrayInstance>, std::shared_ptr<ffi::CCallbackInstance>,
-                          ValueList, ValueMap, ValueOptional> {
-    Value() : std::variant<Int, 
-#if O2L_HAS_INT128
-                          Long,
-#endif
-                          Float, Double, Text, Bool, Char,
-                          std::shared_ptr<ObjectInstance>, std::shared_ptr<EnumInstance>,
-                          std::shared_ptr<RecordType>, std::shared_ptr<RecordInstance>,
-                          std::shared_ptr<ProtocolInstance>, std::shared_ptr<ListInstance>,
-                          std::shared_ptr<ListIterator>, std::shared_ptr<RepeatIterator>,
-                          std::shared_ptr<MapInstance>, std::shared_ptr<MapIterator>,
-                          std::shared_ptr<MapObject>, std::shared_ptr<SetInstance>,
-                          std::shared_ptr<SetIterator>, std::shared_ptr<ErrorInstance>,
-                          std::shared_ptr<ResultInstance>, std::shared_ptr<ffi::PtrInstance>,
-                          std::shared_ptr<ffi::CBufferInstance>, std::shared_ptr<ffi::CStructInstance>,
-                          std::shared_ptr<ffi::CArrayInstance>, std::shared_ptr<ffi::CCallbackInstance>,
-                          ValueList, ValueMap, ValueOptional>(static_cast<Int>(0)) {}
+struct Value : public ValueVariantBase {
+    Value() : ValueVariantBase(static_cast<Int>(0)), is_long_(false) {}
 
     Value(std::nullptr_t) : Value() {}
 
-    using variant::variant;
+    using ValueVariantBase::ValueVariantBase;
 
     // Additional flag to distinguish between Int and Long when they have the same underlying type
     bool is_long_ = false;
 
     // Constructors to set the flag
-    Value(Int v) : variant(v), is_long_(false) {}
+    Value(Int v) : ValueVariantBase(v), is_long_(false) {}
 #if !O2L_HAS_INT128
     // Special constructor for Long when it's the same as Int
     struct LongTag {};
-    Value(Long v, LongTag) : variant(v), is_long_(true) {}
+    Value(Long v, LongTag) : ValueVariantBase(v), is_long_(true) {}
 #else
-    Value(Long v) : variant(v), is_long_(true) {}
+    Value(Long v) : ValueVariantBase(v), is_long_(true) {}
 #endif
 };
 
@@ -155,15 +156,31 @@ bool valuesLess(const Value& a, const Value& b);
 // On platforms with __int128 (Linux/macOS) Long occupies its own variant slot (index 1).
 // On MSVC/Windows Long=Int=long long; the is_long_ flag distinguishes them at runtime.
 #if O2L_HAS_INT128
-inline bool holds_Int_Value(const Value& v) { return v.index() == 0; }
-inline Int  get_Int_Value(const Value& v)   { return std::get<0>(v); }
-inline bool holds_Long_Value(const Value& v) { return v.index() == 1; }
-inline Long get_Long_Value(const Value& v)   { return std::get<1>(v); }
+inline bool holds_Int_Value(const Value& v) {
+    return v.index() == 0;
+}
+inline Int get_Int_Value(const Value& v) {
+    return std::get<0>(v);
+}
+inline bool holds_Long_Value(const Value& v) {
+    return v.index() == 1;
+}
+inline Long get_Long_Value(const Value& v) {
+    return std::get<1>(v);
+}
 #else
-inline bool holds_Int_Value(const Value& v) { return v.index() == 0 && !v.is_long_; }
-inline Int  get_Int_Value(const Value& v)   { return std::get<0>(v); }
-inline bool holds_Long_Value(const Value& v) { return v.index() == 0 && v.is_long_; }
-inline Long get_Long_Value(const Value& v)   { return std::get<0>(v); }
+inline bool holds_Int_Value(const Value& v) {
+    return v.index() == 0 && !v.is_long_;
+}
+inline Int get_Int_Value(const Value& v) {
+    return std::get<0>(v);
+}
+inline bool holds_Long_Value(const Value& v) {
+    return v.index() == 0 && v.is_long_;
+}
+inline Long get_Long_Value(const Value& v) {
+    return std::get<0>(v);
+}
 #endif
 
 // Custom comparator for Value types for use in std::set and std::map

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TEST_SOURCES_LIST
     test_root_exception.cpp
     test_shared_state.cpp
     test_channel_edge_cases.cpp
+    test_io_thread_pool.cpp
     test_break_statement.cpp
     test_continue_statement.cpp
     test_main.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,15 @@ set(TEST_SOURCES_LIST
     test_o2l_fmt.cpp
     test_ffi_simplified.cpp
     test_ffi_library.cpp
+    test_carray_from_list.cpp
+    test_spawn_basic.cpp
+    test_channel_basic.cpp
+    test_scheduler.cpp
+    test_suspend_exception.cpp
+    test_resume_logic.cpp
+    test_context_clone.cpp
+    test_io_yield.cpp
+    test_concurrency_advanced.cpp
     test_break_statement.cpp
     test_continue_statement.cpp
     test_main.cpp
@@ -116,5 +125,14 @@ add_test(NAME protocol_signature_validation_tests COMMAND o2l_tests --gtest_filt
 add_test(NAME o2l_fmt_tests COMMAND o2l_tests --gtest_filter="O2LFmtTest.*")
 add_test(NAME ffi_simplified_tests COMMAND o2l_tests --gtest_filter="FFISimplifiedTest.*")
 add_test(NAME ffi_library_tests COMMAND o2l_tests --gtest_filter="FFILibraryTest.*")
+add_test(NAME carray_from_list_tests COMMAND o2l_tests --gtest_filter="CArrayFromListTest.*")
+add_test(NAME spawn_basic_tests COMMAND o2l_tests --gtest_filter="SpawnBasicTest.*")
+add_test(NAME channel_basic_tests COMMAND o2l_tests --gtest_filter="ChannelBasicTest.*")
+add_test(NAME scheduler_tests COMMAND o2l_tests --gtest_filter="SchedulerTest.*")
+add_test(NAME suspend_exception_tests COMMAND o2l_tests --gtest_filter="SuspendExceptionTest.*")
+add_test(NAME resume_logic_tests COMMAND o2l_tests --gtest_filter="ResumeLogicTest.*")
+add_test(NAME context_clone_tests COMMAND o2l_tests --gtest_filter="ContextCloneTest.*")
+add_test(NAME io_yield_tests COMMAND o2l_tests --gtest_filter="IOYieldTest.*")
+add_test(NAME concurrency_advanced_tests COMMAND o2l_tests --gtest_filter="ConcurrencyAdvancedTest.*")
 add_test(NAME break_statement_tests COMMAND o2l_tests --gtest_filter="BreakStatementTest.*")
 add_test(NAME continue_statement_tests COMMAND o2l_tests --gtest_filter="ContinueStatementTest.*")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set(TEST_SOURCES_LIST
     test_concurrency_advanced.cpp
     test_root_exception.cpp
     test_shared_state.cpp
+    test_channel_edge_cases.cpp
     test_break_statement.cpp
     test_continue_statement.cpp
     test_main.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TEST_SOURCES_LIST
     test_io_yield.cpp
     test_concurrency_advanced.cpp
     test_root_exception.cpp
+    test_shared_state.cpp
     test_break_statement.cpp
     test_continue_statement.cpp
     test_main.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_SOURCES_LIST
     test_context_clone.cpp
     test_io_yield.cpp
     test_concurrency_advanced.cpp
+    test_root_exception.cpp
     test_break_statement.cpp
     test_continue_statement.cpp
     test_main.cpp

--- a/tests/test_carray_from_list.cpp
+++ b/tests/test_carray_from_list.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 O²L Programming Language
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "../src/AST/MethodCallNode.hpp"
+#include "../src/AST/LiteralNode.hpp"
+#include "../src/Runtime/FFI/FFITypes.hpp"
+#include "../src/Runtime/ListInstance.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Value.hpp"
+#include "../src/Common/Exceptions.hpp"
+
+using namespace o2l;
+using namespace o2l::ffi;
+
+class CArrayFromListTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        context = std::make_unique<Context>();
+    }
+
+    std::unique_ptr<Context> context;
+};
+
+// Mock ASTNode that returns a specific value
+class MockCArrayNode : public ASTNode {
+public:
+    Value val;
+    MockCArrayNode(Value v) : ASTNode(SourceLocation{}), val(v) {}
+    Value evaluate(Context&) override { return val; }
+    std::string toString() const override { return "MockCArrayNode"; }
+};
+
+TEST_F(CArrayFromListTest, FromListSuccess) {
+    // 1. Create a CArrayInstance (Int32, size 3)
+    auto array = std::make_shared<CArrayInstance>(CType::Int32, 3);
+    Value array_val(array);
+
+    // 2. Create a ListInstance with 3 elements
+    auto list = std::make_shared<ListInstance>("Int");
+    list->add(Value(Int(10)));
+    list->add(Value(Int(20)));
+    list->add(Value(Int(30)));
+    Value list_val(list);
+
+    // 3. Create MethodCallNode for array.fromList(list)
+    auto obj_node = std::make_unique<MockCArrayNode>(array_val);
+    auto arg_node = std::make_unique<MockCArrayNode>(list_val);
+    
+    std::vector<ASTNodePtr> args;
+    args.push_back(std::move(arg_node));
+    
+    MethodCallNode call_node(std::move(obj_node), "fromList", std::move(args), SourceLocation{});
+
+    // 4. Evaluate
+    Value result = call_node.evaluate(*context);
+
+    // 5. Verify result is Bool(true)
+    EXPECT_TRUE(std::holds_alternative<Bool>(result));
+    EXPECT_TRUE(std::get<Bool>(result));
+
+    // 6. Verify array contents
+    EXPECT_EQ(std::get<Int>(array->getElement(0)), 10);
+    EXPECT_EQ(std::get<Int>(array->getElement(1)), 20);
+    EXPECT_EQ(std::get<Int>(array->getElement(2)), 30);
+}
+
+TEST_F(CArrayFromListTest, FromListSizeMismatch) {
+    auto array = std::make_shared<CArrayInstance>(CType::Int32, 3);
+    auto list = std::make_shared<ListInstance>("Int");
+    list->add(Value(Int(10))); // Only 1 element, expects 3
+    
+    auto obj_node = std::make_unique<MockCArrayNode>(Value(array));
+    auto arg_node = std::make_unique<MockCArrayNode>(Value(list));
+    
+    std::vector<ASTNodePtr> args;
+    args.push_back(std::move(arg_node));
+    
+    MethodCallNode call_node(std::move(obj_node), "fromList", std::move(args), SourceLocation{});
+
+    EXPECT_THROW(call_node.evaluate(*context), EvaluationError);
+}
+
+TEST_F(CArrayFromListTest, FromListTypeMismatch) {
+    auto array = std::make_shared<CArrayInstance>(CType::Int32, 1);
+    
+    auto obj_node = std::make_unique<MockCArrayNode>(Value(array));
+    auto arg_node = std::make_unique<MockCArrayNode>(Value(Int(42))); // Not a list
+    
+    std::vector<ASTNodePtr> args;
+    args.push_back(std::move(arg_node));
+    
+    MethodCallNode call_node(std::move(obj_node), "fromList", std::move(args), SourceLocation{});
+
+    EXPECT_THROW(call_node.evaluate(*context), EvaluationError);
+}

--- a/tests/test_channel_basic.cpp
+++ b/tests/test_channel_basic.cpp
@@ -1,0 +1,75 @@
+﻿#include <cassert>
+#include <iostream>
+#include <memory>
+#include <variant>
+
+#include "../src/Interpreter.hpp"
+#include "../src/Lexer.hpp"
+#include "../src/Parser.hpp"
+#include "../src/Runtime/ChannelInstance.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+using namespace o2l;
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, channel_basic) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Testing Channels (Unbuffered)..." << std::endl;
+
+    std::string source =
+        "Object Main {\n"
+        "  @external method main(): Void {\n"
+        "    ch: Channel = Channel.new()\n"
+        "    spawn {\n"
+        "      ch.send(42)\n"
+        "    }\n"
+        "    val: Int = ch.receive()\n"
+        "    io.print(\"Received: %d\", val)\n"
+        "  }\n"
+        "}";
+
+    // We need to register system.io for io.print
+    Interpreter interpreter;
+
+    // For this test, we'll manually parse and execute
+    Lexer lexer(source);
+    auto tokens = lexer.tokenizeAll();
+    Parser parser(tokens);
+    auto nodes = parser.parse();
+
+    // We expect "Received: 42" to be printed.
+    // Since io.print uses stdout, we can check it.
+
+    std::cout << "--- Program Output ---" << std::endl;
+    interpreter.execute(nodes);
+    std::cout << "--- End Output ---" << std::endl;
+
+    std::cout << "Channel basic test passed!" << std::endl;
+
+    // Buffered channel test
+    std::cout << "Testing Channels (Buffered)..." << std::endl;
+    std::string source_buffered =
+        "Object Main {\n"
+        "  @external method main(): Void {\n"
+        "    ch: Channel = Channel.new(2)\n"
+        "    ch.send(1)\n"
+        "    ch.send(2)\n"
+        "    io.print(\"Sent two values to buffered channel\")\n"
+        "    io.print(\"Recv 1: %d\", ch.receive())\n"
+        "    io.print(\"Recv 2: %d\", ch.receive())\n"
+        "  }\n"
+        "}";
+
+    Lexer lexer2(source_buffered);
+    auto nodes2 = Parser(lexer2.tokenizeAll()).parse();
+
+    std::cout << "--- Buffered Program Output ---" << std::endl;
+    interpreter.execute(nodes2);
+    std::cout << "--- End Output ---" << std::endl;
+
+    return;
+}
+
+

--- a/tests/test_channel_edge_cases.cpp
+++ b/tests/test_channel_edge_cases.cpp
@@ -1,0 +1,117 @@
+#include <iostream>
+#include <memory>
+
+#include "../src/Interpreter.hpp"
+#include "../src/Lexer.hpp"
+#include "../src/Parser.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace o2l;
+
+namespace {
+
+Value runScript(const std::string& source) {
+    Lexer lexer(source);
+    auto nodes = Parser(lexer.tokenizeAll()).parse();
+    Interpreter interpreter;
+    return interpreter.execute(nodes);
+}
+
+}  // anonymous namespace
+
+// AC#1: multiple producers sending to one channel
+TEST(ConcurrencyTest, channel_multiple_producers) {
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new(4)
+                spawn { ch.send(10); ch.send(20) }
+                spawn { ch.send(30); ch.send(40) }
+                v1: Int = ch.receive()
+                v2: Int = ch.receive()
+                v3: Int = ch.receive()
+                v4: Int = ch.receive()
+                return v1 + v2 + v3 + v4
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 100);
+}
+
+// AC#2: multiple consumers receiving from one producer
+TEST(ConcurrencyTest, channel_multiple_consumers) {
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                src: Channel = Channel.new(4)
+                results: Channel = Channel.new(2)
+
+                src.send(10)
+                src.send(20)
+                src.send(30)
+                src.send(40)
+
+                spawn { results.send(src.receive() + src.receive()) }
+                spawn { results.send(src.receive() + src.receive()) }
+
+                r1: Int = results.receive()
+                r2: Int = results.receive()
+                return r1 + r2
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    // Each consumer takes 2 values; total is always 10+20+30+40=100
+    EXPECT_EQ(std::get<Int>(result), 100);
+}
+
+// AC#3: unbuffered channel send blocks until receiver is ready
+TEST(ConcurrencyTest, channel_unbuffered_blocking) {
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new()
+                spawn {
+                    ch.send(99)
+                }
+                val: Int = ch.receive()
+                return val
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 99);
+}
+
+// AC#4: buffered channel at capacity, sender blocks until space available
+TEST(ConcurrencyTest, channel_buffered_full) {
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new(2)
+                ch.send(1)
+                ch.send(2)
+                spawn {
+                    ch.send(3)
+                }
+                v1: Int = ch.receive()
+                v2: Int = ch.receive()
+                v3: Int = ch.receive()
+                return v1 + v2 + v3
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 6);
+}

--- a/tests/test_concurrency_advanced.cpp
+++ b/tests/test_concurrency_advanced.cpp
@@ -1,0 +1,148 @@
+﻿#include "../src/Runtime/Scheduler.hpp"
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../src/Interpreter.hpp"
+#include "../src/Runtime/Value.hpp"
+#include "../src/Common/Exceptions.hpp"
+#include "../src/Lexer.hpp"
+#include "../src/Parser.hpp"
+
+using namespace o2l;
+
+Value runScript(const std::string& source) {
+    Lexer lexer(source);
+    Parser parser(lexer.tokenizeAll());
+    auto ast = parser.parse();
+    Interpreter interpreter;
+    return interpreter.execute(ast);
+}
+
+void testNestedSpawnAndChannelCommunication() {
+    std::cout << "Running testNestedSpawnAndChannelCommunication..." << std::endl;
+    std::string source = R"(
+        Object Worker {
+            method innerWorker(id: Int, ch: Channel): Unit {
+                ch.send(id * 10)
+            }
+            
+            @external method outerWorker(ch: Channel): Unit {
+                innerCh: Channel = Channel.new(2)
+                spawn { this.innerWorker(1, innerCh) }
+                spawn { this.innerWorker(2, innerCh) }
+                
+                v1: Int = innerCh.receive()
+                v2: Int = innerCh.receive()
+                
+                ch.send(v1 + v2)
+            }
+        }
+        
+        Object Main {
+            method main(): Int {
+                results: Channel = Channel.new(1)
+                w: Worker = new Worker()
+                spawn { w.outerWorker(results) }
+                return results.receive()
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    assert(std::holds_alternative<Int>(result));
+    assert(std::get<Int>(result) == 30);
+    std::cout << "  Passed!" << std::endl;
+}
+
+void testClosedChannelSendThrows() {
+    std::cout << "Running testClosedChannelSendThrows..." << std::endl;
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new(1)
+                ch.close()
+                try {
+                    ch.send(42)
+                    return 0
+                } catch (e) {
+                    return 1
+                }
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    assert(std::holds_alternative<Int>(result));
+    assert(std::get<Int>(result) == 1);
+    std::cout << "  Passed!" << std::endl;
+}
+
+void testClosedChannelReceiveEmptyThrows() {
+    std::cout << "Running testClosedChannelReceiveEmptyThrows..." << std::endl;
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new(1)
+                ch.close()
+                try {
+                    val: Int = ch.receive()
+                    return 0
+                } catch (e) {
+                    return 1
+                }
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    assert(std::holds_alternative<Int>(result));
+    assert(std::get<Int>(result) == 1);
+    std::cout << "  Passed!" << std::endl;
+}
+
+void testClosedChannelReceiveBufferedSucceeds() {
+    std::cout << "Running testClosedChannelReceiveBufferedSucceeds..." << std::endl;
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new(2)
+                ch.send(10)
+                ch.send(20)
+                ch.close()
+                
+                v1: Int = ch.receive()
+                v2: Int = ch.receive()
+                
+                try {
+                    v3: Int = ch.receive()
+                    return -1
+                } catch (e) {
+                    return v1 + v2
+                }
+            }
+        }
+    )";
+
+    Value result = runScript(source);
+    assert(std::holds_alternative<Int>(result));
+    assert(std::get<Int>(result) == 30);
+    std::cout << "  Passed!" << std::endl;
+}
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, concurrency_advanced) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "--- Concurrency Advanced Tests ---" << std::endl;
+    testNestedSpawnAndChannelCommunication();
+    testClosedChannelSendThrows();
+    testClosedChannelReceiveEmptyThrows();
+    testClosedChannelReceiveBufferedSucceeds();
+    std::cout << "All advanced concurrency tests passed!" << std::endl;
+    return;
+}
+
+
+

--- a/tests/test_context_clone.cpp
+++ b/tests/test_context_clone.cpp
@@ -1,0 +1,56 @@
+﻿#include "../src/Runtime/Scheduler.hpp"
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <variant>
+
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/ObjectInstance.hpp"
+#include "../src/Runtime/Value.hpp"
+
+using namespace o2l;
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, context_clone) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Testing Context::clone()..." << std::endl;
+
+    Context original;
+    original.defineVariable("x", Int(10));
+    original.defineVariable("msg", Text("hello"));
+
+    auto obj = std::make_shared<ObjectInstance>("TestObj");
+    original.defineConstant("obj", obj);
+
+    // Clone the context
+    Context cloned = original.clone();
+
+    // Verify values are preserved
+    assert(std::get<Int>(cloned.getVariable("x")) == 10);
+    assert(std::get<Text>(cloned.getVariable("msg")) == "hello");
+    assert(std::get<std::shared_ptr<ObjectInstance>>(cloned.getVariable("obj")) == obj);
+
+    // Verify isolation of variables
+    cloned.reassignVariable("x", Int(20));
+    assert(std::get<Int>(cloned.getVariable("x")) == 20);
+    assert(std::get<Int>(original.getVariable("x")) == 10);
+
+    // Verify sharing of objects
+    auto obj_in_cloned = std::get<std::shared_ptr<ObjectInstance>>(cloned.getVariable("obj"));
+    assert(obj_in_cloned == obj);
+
+    // Verify isolation of scope stack
+    cloned.pushScope();
+    cloned.defineVariable("y", Int(30));
+    assert(cloned.hasVariable("y"));
+    assert(!original.hasVariable("y"));
+    cloned.popScope();
+    assert(!cloned.hasVariable("y"));
+
+    std::cout << "Context::clone() test passed!" << std::endl;
+    return;
+}
+
+
+

--- a/tests/test_io_thread_pool.cpp
+++ b/tests/test_io_thread_pool.cpp
@@ -1,0 +1,108 @@
+#include <atomic>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include "../src/AST/Node.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace o2l;
+
+namespace {
+
+// A node that suspends for IO, returning the IO result on resume
+class IONode : public ASTNode {
+   public:
+    std::function<Value()> work;
+    Value* result_out;
+
+    IONode(std::function<Value()> w, Value* out)
+        : work(std::move(w)), result_out(out) {}
+
+    Value evaluate(Context& context) override {
+        (void)context;
+        auto& sched = Scheduler::instance();
+        if (sched.hasResumeValue()) {
+            Value v = sched.consumeResumeValue();
+            if (result_out) *result_out = v;
+            return v;
+        }
+        sched.suspendForIO(work);
+        return Value(static_cast<Int>(0));  // unreachable
+    }
+    std::string toString() const override { return "io_node"; }
+};
+
+}  // anonymous namespace
+
+// AC#1: suspendForIO delivers lambda result to coroutine on resume
+TEST(ConcurrencyTest, suspend_for_io_basic) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    Value result;
+    auto node = std::make_unique<IONode>(
+        []() -> Value { return Value(static_cast<Int>(42)); },
+        &result);
+
+    sched.spawn(node.get(), Context());
+    sched.run();
+
+    EXPECT_EQ(sched.getRootException(), nullptr);
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 42);
+}
+
+// AC#2: IO work runs on a different thread
+TEST(ConcurrencyTest, suspend_for_io_different_thread) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    auto main_tid = std::this_thread::get_id();
+    std::thread::id io_tid;
+
+    Value result;
+    auto node = std::make_unique<IONode>(
+        [&io_tid]() -> Value {
+            io_tid = std::this_thread::get_id();
+            return Value(static_cast<Int>(1));
+        },
+        &result);
+
+    sched.spawn(node.get(), Context());
+    sched.run();
+
+    EXPECT_EQ(sched.getRootException(), nullptr);
+    EXPECT_NE(io_tid, std::thread::id{});  // was actually set
+    EXPECT_NE(io_tid, main_tid);           // ran on a different thread
+}
+
+// AC#3: multiple concurrent IO suspensions all complete
+TEST(ConcurrencyTest, suspend_for_io_multiple) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    Value r1, r2, r3;
+    auto n1 = std::make_unique<IONode>(
+        []() -> Value { return Value(static_cast<Int>(10)); }, &r1);
+    auto n2 = std::make_unique<IONode>(
+        []() -> Value { return Value(static_cast<Int>(20)); }, &r2);
+    auto n3 = std::make_unique<IONode>(
+        []() -> Value { return Value(static_cast<Int>(30)); }, &r3);
+
+    sched.spawn(n1.get(), Context());
+    sched.spawn(n2.get(), Context());
+    sched.spawn(n3.get(), Context());
+    sched.run();
+
+    EXPECT_EQ(sched.getRootException(), nullptr);
+    ASSERT_TRUE(std::holds_alternative<Int>(r1));
+    ASSERT_TRUE(std::holds_alternative<Int>(r2));
+    ASSERT_TRUE(std::holds_alternative<Int>(r3));
+    EXPECT_EQ(std::get<Int>(r1), 10);
+    EXPECT_EQ(std::get<Int>(r2), 20);
+    EXPECT_EQ(std::get<Int>(r3), 30);
+}

--- a/tests/test_io_yield.cpp
+++ b/tests/test_io_yield.cpp
@@ -1,0 +1,61 @@
+﻿#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <variant>
+
+#include "../src/Lexer.hpp"
+#include "../src/Parser.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/CoroutineHandle.hpp"
+#include "../src/Runtime/ModuleLoader.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+using namespace o2l;
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, io_yield) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Testing Concurrency Yield Points (sleep)..." << std::endl;
+
+    // We need to register native methods if we want to test sleep()
+    // but sleep() is also a built-in recognized in FunctionCallNode::evaluate()
+
+    std::string source =
+        "spawn { "
+        "  sleep(100); "
+        "  var x: Int = 42; "
+        "}";
+
+    Lexer lexer(source);
+    auto tokens = lexer.tokenizeAll();
+    Parser parser(tokens);
+    auto nodes = parser.parse();
+
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    Context context;
+    // We need to make sure ModuleLoader is initialized if we use it,
+    // but here we are using built-in sleep.
+
+    std::cout << "  Spawning coroutine..." << std::endl;
+    nodes[0]->evaluate(context);
+
+    auto start = std::chrono::steady_clock::now();
+    std::cout << "  Running scheduler..." << std::endl;
+    sched.run();
+    auto end = std::chrono::steady_clock::now();
+
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    std::cout << "  Scheduler ran for " << duration << "ms." << std::endl;
+
+    assert(duration >= 100);
+    std::cout << "  [âœ“] Scheduler respected sleep() duration." << std::endl;
+
+    std::cout << "Concurrency yield point tests passed!" << std::endl;
+    return;
+}
+
+

--- a/tests/test_resume_logic.cpp
+++ b/tests/test_resume_logic.cpp
@@ -362,3 +362,142 @@ TEST(ConcurrencyTest, error_in_condition_after_resume) {
     ASSERT_NE(sched.getRootException(), nullptr);
     EXPECT_FALSE(sched.isActive());
 }
+
+// AC#1 (task-005): yield inside inner loop of nested while-while
+TEST(ConcurrencyTest, yield_nested_inner_loop) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+    g_yield_count = 0;
+
+    // var i: Int = 0;
+    // var j: Int = 0;
+    // while (i < 2) {
+    //   j = 0;
+    //   while (j < 2) {
+    //     yield;
+    //     j = j + 1;
+    //   }
+    //   i = i + 1;
+    // }
+    SourceLocation loc;
+    auto decl_i = std::make_unique<VariableDeclarationNode>(
+        "i", "Int", std::make_unique<LiteralNode>(Int(0)));
+    auto decl_j = std::make_unique<VariableDeclarationNode>(
+        "j", "Int", std::make_unique<LiteralNode>(Int(0)));
+
+    // Inner condition: j < 2
+    auto inner_cond = std::make_unique<ComparisonNode>(
+        std::make_unique<IdentifierNode>("j"), ComparisonOperator::LESS_THAN,
+        std::make_unique<LiteralNode>(Int(2)), loc);
+
+    // Inner body: { yield; j = j + 1; }
+    auto inc_j = std::make_unique<VariableAssignmentNode>(
+        "j", std::make_unique<BinaryOpNode>(
+                 std::make_unique<IdentifierNode>("j"), BinaryOperator::PLUS,
+                 std::make_unique<LiteralNode>(Int(1)), loc));
+    std::vector<ASTNodePtr> inner_body_stmts;
+    inner_body_stmts.push_back(std::make_unique<YieldNode>());
+    inner_body_stmts.push_back(std::move(inc_j));
+    auto inner_body = std::make_unique<BlockNode>(std::move(inner_body_stmts));
+
+    auto inner_while = std::make_unique<WhileStatementNode>(
+        std::move(inner_cond), std::move(inner_body));
+
+    // Outer condition: i < 2
+    auto outer_cond = std::make_unique<ComparisonNode>(
+        std::make_unique<IdentifierNode>("i"), ComparisonOperator::LESS_THAN,
+        std::make_unique<LiteralNode>(Int(2)), loc);
+
+    // Outer body: { j = 0; inner_while; i = i + 1; }
+    auto reset_j = std::make_unique<VariableAssignmentNode>(
+        "j", std::make_unique<LiteralNode>(Int(0)));
+    auto inc_i = std::make_unique<VariableAssignmentNode>(
+        "i", std::make_unique<BinaryOpNode>(
+                 std::make_unique<IdentifierNode>("i"), BinaryOperator::PLUS,
+                 std::make_unique<LiteralNode>(Int(1)), loc));
+    std::vector<ASTNodePtr> outer_body_stmts;
+    outer_body_stmts.push_back(std::move(reset_j));
+    outer_body_stmts.push_back(std::move(inner_while));
+    outer_body_stmts.push_back(std::move(inc_i));
+    auto outer_body = std::make_unique<BlockNode>(std::move(outer_body_stmts));
+
+    auto outer_while = std::make_unique<WhileStatementNode>(
+        std::move(outer_cond), std::move(outer_body));
+
+    Context context;
+    decl_i->evaluate(context);
+    decl_j->evaluate(context);
+    sched.spawn(outer_while.get(), std::move(context));
+    sched.run();
+
+    // 2 outer iterations * 2 inner iterations = 4 yields
+    EXPECT_EQ(g_yield_count, 4);
+    EXPECT_EQ(sched.getRootException(), nullptr);
+}
+
+// AC#2 (task-005): yield in outer loop body after inner loop completes
+TEST(ConcurrencyTest, yield_nested_outer_body) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+    g_yield_count = 0;
+
+    // var i: Int = 0;
+    // var j: Int = 0;
+    // while (i < 2) {
+    //   j = 0;
+    //   while (j < 2) {
+    //     j = j + 1;     // no yield in inner loop
+    //   }
+    //   yield;            // yield in outer body after inner loop
+    //   i = i + 1;
+    // }
+    SourceLocation loc;
+    auto decl_i = std::make_unique<VariableDeclarationNode>(
+        "i", "Int", std::make_unique<LiteralNode>(Int(0)));
+    auto decl_j = std::make_unique<VariableDeclarationNode>(
+        "j", "Int", std::make_unique<LiteralNode>(Int(0)));
+
+    // Inner loop: while (j < 2) { j = j + 1; }
+    auto inner_cond = std::make_unique<ComparisonNode>(
+        std::make_unique<IdentifierNode>("j"), ComparisonOperator::LESS_THAN,
+        std::make_unique<LiteralNode>(Int(2)), loc);
+    auto inc_j = std::make_unique<VariableAssignmentNode>(
+        "j", std::make_unique<BinaryOpNode>(
+                 std::make_unique<IdentifierNode>("j"), BinaryOperator::PLUS,
+                 std::make_unique<LiteralNode>(Int(1)), loc));
+    std::vector<ASTNodePtr> inner_body_stmts;
+    inner_body_stmts.push_back(std::move(inc_j));
+    auto inner_body = std::make_unique<BlockNode>(std::move(inner_body_stmts));
+    auto inner_while = std::make_unique<WhileStatementNode>(
+        std::move(inner_cond), std::move(inner_body));
+
+    // Outer loop body: { j = 0; inner_while; yield; i = i + 1; }
+    auto outer_cond = std::make_unique<ComparisonNode>(
+        std::make_unique<IdentifierNode>("i"), ComparisonOperator::LESS_THAN,
+        std::make_unique<LiteralNode>(Int(2)), loc);
+    auto reset_j = std::make_unique<VariableAssignmentNode>(
+        "j", std::make_unique<LiteralNode>(Int(0)));
+    auto inc_i = std::make_unique<VariableAssignmentNode>(
+        "i", std::make_unique<BinaryOpNode>(
+                 std::make_unique<IdentifierNode>("i"), BinaryOperator::PLUS,
+                 std::make_unique<LiteralNode>(Int(1)), loc));
+    std::vector<ASTNodePtr> outer_body_stmts;
+    outer_body_stmts.push_back(std::move(reset_j));
+    outer_body_stmts.push_back(std::move(inner_while));
+    outer_body_stmts.push_back(std::make_unique<YieldNode>());
+    outer_body_stmts.push_back(std::move(inc_i));
+    auto outer_body = std::make_unique<BlockNode>(std::move(outer_body_stmts));
+
+    auto outer_while = std::make_unique<WhileStatementNode>(
+        std::move(outer_cond), std::move(outer_body));
+
+    Context context;
+    decl_i->evaluate(context);
+    decl_j->evaluate(context);
+    sched.spawn(outer_while.get(), std::move(context));
+    sched.run();
+
+    // 2 outer iterations, each yields once after inner loop completes
+    EXPECT_EQ(g_yield_count, 2);
+    EXPECT_EQ(sched.getRootException(), nullptr);
+}

--- a/tests/test_resume_logic.cpp
+++ b/tests/test_resume_logic.cpp
@@ -1,0 +1,101 @@
+﻿#include <cassert>
+#include <iostream>
+#include <memory>
+#include <variant>
+
+#include "../src/AST/BinaryOpNode.hpp"
+#include "../src/AST/BlockNode.hpp"
+#include "../src/AST/ComparisonNode.hpp"
+#include "../src/AST/IdentifierNode.hpp"
+#include "../src/AST/LiteralNode.hpp"
+#include "../src/AST/Node.hpp"
+#include "../src/AST/VariableAssignmentNode.hpp"
+#include "../src/AST/VariableDeclarationNode.hpp"
+#include "../src/AST/WhileStatementNode.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Coroutine.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+using namespace o2l;
+
+// Global counter for yields
+static int g_yield_count = 0;
+
+class YieldNode : public ASTNode {
+   public:
+    Value evaluate(Context& context) override {
+        if (Scheduler::instance().hasResumeValue()) {
+            Scheduler::instance().consumeResumeValue();
+            return Int(0);
+        }
+        g_yield_count++;
+        Scheduler::instance().yield();
+        return Int(0);
+    }
+    std::string toString() const override {
+        return "yield";
+    }
+};
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, resume_logic) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Testing statement-level resumption..." << std::endl;
+
+    auto& sched = Scheduler::instance();
+    Context context;
+
+    /*
+     * var i: Int = 0;
+     * while (i < 2) {
+     *   yield;
+     *   i = i + 1;
+     * }
+     */
+
+    SourceLocation loc;
+    auto var_decl = std::make_unique<VariableDeclarationNode>(
+        "i", "Int", std::make_unique<LiteralNode>(Int(0)));
+
+    auto condition = std::make_unique<ComparisonNode>(std::make_unique<IdentifierNode>("i"),
+                                                      ComparisonOperator::LESS_THAN,
+                                                      std::make_unique<LiteralNode>(Int(2)), loc);
+
+    auto yield_stmt = std::make_unique<YieldNode>();
+    auto increment = std::make_unique<VariableAssignmentNode>(
+        "i",
+        std::make_unique<BinaryOpNode>(std::make_unique<IdentifierNode>("i"), BinaryOperator::PLUS,
+                                       std::make_unique<LiteralNode>(Int(1)), loc));
+
+    std::vector<ASTNodePtr> body_stmts;
+    body_stmts.push_back(std::move(yield_stmt));
+    body_stmts.push_back(std::move(increment));
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(body));
+
+    // 1. Initial declaration
+    var_decl->evaluate(context);
+
+    // 2. Spawn coroutine
+    sched.spawn(while_stmt.get(), std::move(context));
+
+    // 3. Run
+    sched.run();
+
+    // EXPECTATION:
+    // Iteration 0: Hits yield (stmt 0 of block), suspends. g_yield_count = 1, i = 0.
+    // Iteration 0 resumed: Resumes at stmt 0, completes it, executes stmt 1 (i=1).
+    // Iteration 1: Hits condition (1 < 2), enters body, hits yield (stmt 0), suspends.
+    // g_yield_count = 2, i = 1. Iteration 1 resumed: Resumes at stmt 0, completes it, executes stmt
+    // 1 (i=2). Iteration 2: Condition (2 < 2) is false, loop terminates.
+
+    std::cout << "  Yield count: " << g_yield_count << std::endl;
+    assert(g_yield_count == 2);
+
+    std::cout << "Resumption tests passed!" << std::endl;
+    return;
+}
+
+

--- a/tests/test_resume_logic.cpp
+++ b/tests/test_resume_logic.cpp
@@ -16,7 +16,11 @@
 #include "../src/Runtime/Coroutine.hpp"
 #include "../src/Runtime/Scheduler.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace o2l;
+
+namespace {
 
 // Global counter for yields
 static int g_yield_count = 0;
@@ -24,20 +28,21 @@ static int g_yield_count = 0;
 class YieldNode : public ASTNode {
    public:
     Value evaluate(Context& context) override {
-        if (Scheduler::instance().hasResumeValue()) {
-            Scheduler::instance().consumeResumeValue();
-            return Int(0);
+        (void)context;
+        auto& sched = Scheduler::instance();
+        if (sched.hasResumeValue()) {
+            return sched.consumeResumeValue();
         }
-        g_yield_count++;
-        Scheduler::instance().yield();
-        return Int(0);
+        ++g_yield_count;
+        sched.yield();
+        return Value(static_cast<Int>(0));
     }
     std::string toString() const override {
         return "yield";
     }
 };
 
-#include <gtest/gtest.h>
+}  // anonymous namespace
 
 TEST(ConcurrencyTest, resume_logic) {
     o2l::Scheduler::instance().reset();
@@ -92,10 +97,7 @@ TEST(ConcurrencyTest, resume_logic) {
     // 1 (i=2). Iteration 2: Condition (2 < 2) is false, loop terminates.
 
     std::cout << "  Yield count: " << g_yield_count << std::endl;
-    assert(g_yield_count == 2);
+    EXPECT_EQ(g_yield_count, 2);
 
     std::cout << "Resumption tests passed!" << std::endl;
-    return;
 }
-
-

--- a/tests/test_resume_logic.cpp
+++ b/tests/test_resume_logic.cpp
@@ -101,3 +101,120 @@ TEST(ConcurrencyTest, resume_logic) {
 
     std::cout << "Resumption tests passed!" << std::endl;
 }
+
+// AC#1: yield inside while(false) — coroutine completes without ever yielding
+TEST(ConcurrencyTest, yield_in_false_loop) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+    g_yield_count = 0;
+
+    // while (false) { yield; }
+    SourceLocation loc;
+    auto condition = std::make_unique<LiteralNode>(Bool(false));
+
+    std::vector<ASTNodePtr> body_stmts;
+    body_stmts.push_back(std::make_unique<YieldNode>());
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(body));
+
+    Context context;
+    sched.spawn(while_stmt.get(), std::move(context));
+    sched.run();
+
+    EXPECT_EQ(g_yield_count, 0);
+}
+
+// AC#2: yield where condition becomes false on the resume iteration
+TEST(ConcurrencyTest, yield_single_iteration) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+    g_yield_count = 0;
+
+    // var i: Int = 0;
+    // while (i < 1) { yield; i = i + 1; }
+    SourceLocation loc;
+    auto var_decl = std::make_unique<VariableDeclarationNode>(
+        "i", "Int", std::make_unique<LiteralNode>(Int(0)));
+
+    auto condition = std::make_unique<ComparisonNode>(
+        std::make_unique<IdentifierNode>("i"), ComparisonOperator::LESS_THAN,
+        std::make_unique<LiteralNode>(Int(1)), loc);
+
+    auto increment = std::make_unique<VariableAssignmentNode>(
+        "i", std::make_unique<BinaryOpNode>(
+                 std::make_unique<IdentifierNode>("i"), BinaryOperator::PLUS,
+                 std::make_unique<LiteralNode>(Int(1)), loc));
+
+    std::vector<ASTNodePtr> body_stmts;
+    body_stmts.push_back(std::make_unique<YieldNode>());
+    body_stmts.push_back(std::move(increment));
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(body));
+
+    Context context;
+    var_decl->evaluate(context);
+    sched.spawn(while_stmt.get(), std::move(context));
+    sched.run();
+
+    // Yields once (i=0 < 1), resumes, increments i to 1, condition 1<1 false, done.
+    EXPECT_EQ(g_yield_count, 1);
+}
+
+// AC#3: yield in deeply nested blocks (3 levels of BlockNode)
+TEST(ConcurrencyTest, yield_deeply_nested) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+    g_yield_count = 0;
+
+    // var i: Int = 0;
+    // while (i < 1) {
+    //   {              // outer block
+    //     {            // middle block
+    //       {          // inner block
+    //         yield;
+    //         i = i + 1;
+    //       }
+    //     }
+    //   }
+    // }
+    SourceLocation loc;
+    auto var_decl = std::make_unique<VariableDeclarationNode>(
+        "i", "Int", std::make_unique<LiteralNode>(Int(0)));
+
+    auto condition = std::make_unique<ComparisonNode>(
+        std::make_unique<IdentifierNode>("i"), ComparisonOperator::LESS_THAN,
+        std::make_unique<LiteralNode>(Int(1)), loc);
+
+    auto increment = std::make_unique<VariableAssignmentNode>(
+        "i", std::make_unique<BinaryOpNode>(
+                 std::make_unique<IdentifierNode>("i"), BinaryOperator::PLUS,
+                 std::make_unique<LiteralNode>(Int(1)), loc));
+
+    // Inner block: { yield; i = i + 1; }
+    std::vector<ASTNodePtr> inner_stmts;
+    inner_stmts.push_back(std::make_unique<YieldNode>());
+    inner_stmts.push_back(std::move(increment));
+    auto inner_block = std::make_unique<BlockNode>(std::move(inner_stmts));
+
+    // Middle block: { inner_block }
+    std::vector<ASTNodePtr> middle_stmts;
+    middle_stmts.push_back(std::move(inner_block));
+    auto middle_block = std::make_unique<BlockNode>(std::move(middle_stmts));
+
+    // Outer block (while body): { middle_block }
+    std::vector<ASTNodePtr> outer_stmts;
+    outer_stmts.push_back(std::move(middle_block));
+    auto outer_block = std::make_unique<BlockNode>(std::move(outer_stmts));
+
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(outer_block));
+
+    Context context;
+    var_decl->evaluate(context);
+    sched.spawn(while_stmt.get(), std::move(context));
+    sched.run();
+
+    // block_resume_stack should handle 3 levels of BlockNode + WhileStatementNode
+    EXPECT_EQ(g_yield_count, 1);
+}

--- a/tests/test_resume_logic.cpp
+++ b/tests/test_resume_logic.cpp
@@ -1,6 +1,7 @@
 ﻿#include <cassert>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <variant>
 
 #include "../src/AST/BinaryOpNode.hpp"
@@ -22,8 +23,9 @@ using namespace o2l;
 
 namespace {
 
-// Global counter for yields
+// Shared counters reset per test
 static int g_yield_count = 0;
+static int g_post_yield_count = 0;
 
 class YieldNode : public ASTNode {
    public:
@@ -40,6 +42,58 @@ class YieldNode : public ASTNode {
     std::string toString() const override {
         return "yield";
     }
+};
+
+class ErrorNode : public ASTNode {
+   public:
+    Value evaluate(Context& context) override {
+        (void)context;
+        throw std::runtime_error("coroutine error");
+    }
+    std::string toString() const override { return "error"; }
+};
+
+// A node that yields on first call, then throws on resume
+class YieldThenErrorNode : public ASTNode {
+   public:
+    Value evaluate(Context& context) override {
+        (void)context;
+        auto& sched = Scheduler::instance();
+        if (sched.hasResumeValue()) {
+            sched.consumeResumeValue();
+            throw std::runtime_error("error after resume");
+        }
+        sched.yield();
+        return Value(static_cast<Int>(0));
+    }
+    std::string toString() const override { return "yield_then_error"; }
+};
+
+// A condition node that succeeds N times then throws
+class CountdownConditionNode : public ASTNode {
+   public:
+    int* remaining;
+    explicit CountdownConditionNode(int* r) : remaining(r) {}
+    Value evaluate(Context& context) override {
+        (void)context;
+        if (*remaining <= 0) {
+            throw std::runtime_error("condition error");
+        }
+        (*remaining)--;
+        return Value(Bool(true));
+    }
+    std::string toString() const override { return "countdown_cond"; }
+};
+
+// A node that records post-yield execution (proves resume happened before error)
+class PostYieldCounterNode : public ASTNode {
+   public:
+    Value evaluate(Context& context) override {
+        (void)context;
+        ++g_post_yield_count;
+        return Value(static_cast<Int>(0));
+    }
+    std::string toString() const override { return "post_yield_counter"; }
 };
 
 }  // anonymous namespace
@@ -217,4 +271,94 @@ TEST(ConcurrencyTest, yield_deeply_nested) {
 
     // block_resume_stack should handle 3 levels of BlockNode + WhileStatementNode
     EXPECT_EQ(g_yield_count, 1);
+}
+
+// AC#1 (task-004): error thrown after yield propagates to scheduler
+TEST(ConcurrencyTest, error_after_resume) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    // while (true) { yield_then_error; }
+    // First run: yields. Resume: throws runtime_error.
+    auto condition = std::make_unique<LiteralNode>(Bool(true));
+
+    std::vector<ASTNodePtr> body_stmts;
+    body_stmts.push_back(std::make_unique<YieldThenErrorNode>());
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(body));
+
+    Context context;
+    sched.spawn(while_stmt.get(), std::move(context));  // id=0 (root)
+    sched.run();
+
+    // Root coroutine should have failed with our error
+    ASSERT_NE(sched.getRootException(), nullptr);
+    try {
+        std::rethrow_exception(sched.getRootException());
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ(e.what(), "error after resume");
+    }
+}
+
+// AC#2 (task-004): scheduler queues are drained after both success and failure
+TEST(ConcurrencyTest, scheduler_clean_after_run) {
+    auto& sched = Scheduler::instance();
+
+    // Case 1: successful completion
+    sched.reset();
+    auto success = std::make_unique<LiteralNode>(Int(1));
+    sched.spawn(success.get(), Context());
+    sched.run();
+    EXPECT_FALSE(sched.isActive());
+    EXPECT_EQ(sched.getRootException(), nullptr);
+
+    // Case 2: error completion
+    sched.reset();
+    auto error = std::make_unique<ErrorNode>();
+    sched.spawn(error.get(), Context());
+    sched.run();
+    EXPECT_FALSE(sched.isActive());
+    EXPECT_NE(sched.getRootException(), nullptr);
+
+    // Case 3: yield then error — scheduler should still drain
+    sched.reset();
+    auto cond = std::make_unique<LiteralNode>(Bool(true));
+    std::vector<ASTNodePtr> stmts;
+    stmts.push_back(std::make_unique<YieldThenErrorNode>());
+    auto blk = std::make_unique<BlockNode>(std::move(stmts));
+    auto ws = std::make_unique<WhileStatementNode>(std::move(cond), std::move(blk));
+    sched.spawn(ws.get(), Context());
+    sched.run();
+    EXPECT_FALSE(sched.isActive());
+}
+
+// AC#3 (task-004): error during condition evaluation doesn't leave stale state
+TEST(ConcurrencyTest, error_in_condition_after_resume) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+    g_yield_count = 0;
+    g_post_yield_count = 0;
+
+    // countdown starts at 1: first condition eval succeeds (returns true),
+    // body yields, resume completes, second condition eval throws.
+    int countdown = 1;
+    auto condition = std::make_unique<CountdownConditionNode>(&countdown);
+
+    std::vector<ASTNodePtr> body_stmts;
+    body_stmts.push_back(std::make_unique<YieldNode>());
+    body_stmts.push_back(std::make_unique<PostYieldCounterNode>());
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(body));
+
+    Context context;
+    sched.spawn(while_stmt.get(), std::move(context));
+    sched.run();
+
+    // Yield happened once, then resume ran post-yield counter, then condition threw
+    EXPECT_EQ(g_yield_count, 1);
+    EXPECT_EQ(g_post_yield_count, 1);
+    ASSERT_NE(sched.getRootException(), nullptr);
+    EXPECT_FALSE(sched.isActive());
 }

--- a/tests/test_root_exception.cpp
+++ b/tests/test_root_exception.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+#include "../src/AST/LiteralNode.hpp"
+#include "../src/AST/Node.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace o2l;
+
+namespace {
+
+class SuccessNode : public ASTNode {
+   public:
+    Value evaluate(Context& context) override {
+        (void)context;
+        return Value(static_cast<Int>(42));
+    }
+    std::string toString() const override { return "success"; }
+};
+
+class ErrorNode : public ASTNode {
+   public:
+    Value evaluate(Context& context) override {
+        (void)context;
+        throw std::runtime_error("coroutine error");
+    }
+    std::string toString() const override { return "error"; }
+};
+
+}  // anonymous namespace
+
+// AC#1: root coroutine error is captured in root_exception_
+TEST(ConcurrencyTest, root_exception_captured) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    auto error_node = std::make_unique<ErrorNode>();
+    sched.spawn(error_node.get(), Context());  // id=0 (root)
+    sched.run();
+
+    ASSERT_NE(sched.getRootException(), nullptr);
+    EXPECT_THROW(std::rethrow_exception(sched.getRootException()), std::runtime_error);
+}
+
+// AC#2: non-root coroutine error does NOT set root_exception_
+TEST(ConcurrencyTest, non_root_exception_ignored) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    auto success_node = std::make_unique<SuccessNode>();
+    auto error_node = std::make_unique<ErrorNode>();
+
+    sched.spawn(success_node.get(), Context());  // id=0 (root) — succeeds
+    sched.spawn(error_node.get(), Context());     // id=1 — fails
+
+    sched.run();
+
+    EXPECT_EQ(sched.getRootException(), nullptr);
+    EXPECT_EQ(std::get<Int>(sched.getRootResult()), 42);
+}
+
+// AC#3: root_exception_ is null on successful completion
+TEST(ConcurrencyTest, root_exception_null_on_success) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    auto success_node = std::make_unique<SuccessNode>();
+    sched.spawn(success_node.get(), Context());  // id=0 (root)
+    sched.run();
+
+    EXPECT_EQ(sched.getRootException(), nullptr);
+    EXPECT_EQ(std::get<Int>(sched.getRootResult()), 42);
+}

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -1,0 +1,126 @@
+﻿#include <cassert>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../src/AST/Node.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+#include "../src/Runtime/Value.hpp"
+
+using namespace o2l;
+
+// A node that yields N times and records its execution order
+class TaskNode : public ASTNode {
+   public:
+    std::string name;
+    int yields_remaining;
+    std::vector<std::string>* execution_log;
+
+    TaskNode(std::string name, int yields, std::vector<std::string>* log)
+        : name(name), yields_remaining(yields), execution_log(log) {}
+
+    Value evaluate(Context& context) override {
+        if (Scheduler::instance().hasResumeValue()) {
+            Scheduler::instance().consumeResumeValue();
+        }
+
+        while (yields_remaining > 0) {
+            execution_log->push_back(name + "_yield_" + std::to_string(yields_remaining));
+            yields_remaining--;
+            Scheduler::instance().yield();
+            // After yield, we need to handle resumption for the next iteration if this were a
+            // BlockNode, but since we are in a manual while loop, we will just continue. Actually,
+            // if yield throws, we exit. On re-entry, we hit the hasResumeValue check at the top.
+        }
+        execution_log->push_back(name + "_done");
+        return Int(0);
+    }
+
+    std::string toString() const override {
+        return name;
+    }
+};
+
+// A node for testing sleep
+class SleepNode : public ASTNode {
+   public:
+    uint64_t ms;
+    bool* finished;
+    SleepNode(uint64_t ms, bool* finished) : ms(ms), finished(finished) {}
+
+    Value evaluate(Context& context) override {
+        if (Scheduler::instance().hasResumeValue()) {
+            Scheduler::instance().consumeResumeValue();
+            *finished = true;
+            return Int(1);
+        }
+        Scheduler::instance().suspendForSleep(ms);
+        *finished = true;
+        return Int(1);
+    }
+
+    std::string toString() const override {
+        return "sleep";
+    }
+};
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, scheduler) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Testing Scheduler..." << std::endl;
+
+    auto& sched = Scheduler::instance();
+    std::vector<std::string> log;
+
+    // Test 1: Round-robin execution
+    std::cout << "  Test 1: Round-robin..." << std::endl;
+    auto task1 = std::make_unique<TaskNode>("A", 2, &log);
+    auto task2 = std::make_unique<TaskNode>("B", 2, &log);
+    auto task3 = std::make_unique<TaskNode>("C", 2, &log);
+
+    sched.spawn(task1.get(), Context());
+    sched.spawn(task2.get(), Context());
+    sched.spawn(task3.get(), Context());
+
+    sched.run();
+
+    // Expected order (Round Robin):
+    // A_yield_2, B_yield_2, C_yield_2,
+    // A_yield_1, B_yield_1, C_yield_1,
+    // A_done, B_done, C_done
+
+    assert(log.size() == 9);
+    assert(log[0] == "A_yield_2");
+    assert(log[1] == "B_yield_2");
+    assert(log[2] == "C_yield_2");
+    assert(log[3] == "A_yield_1");
+    assert(log[4] == "B_yield_1");
+    assert(log[5] == "C_yield_1");
+    assert(log[6] == "A_done");
+    assert(log[7] == "B_done");
+    assert(log[8] == "C_done");
+    std::cout << "    [âœ“] Round-robin passed." << std::endl;
+
+    // Test 2: Sleep timers
+    std::cout << "  Test 2: Sleep timers..." << std::endl;
+    bool sleep_finished = false;
+    auto sleep_task = std::make_unique<SleepNode>(50, &sleep_finished);
+
+    auto start = std::chrono::steady_clock::now();
+    sched.spawn(sleep_task.get(), Context());
+    sched.run();
+    auto end = std::chrono::steady_clock::now();
+
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    assert(sleep_finished);
+    assert(duration >= 45);  // Tolerance
+    std::cout << "    [âœ“] Sleep timer passed (duration: " << duration << "ms)." << std::endl;
+
+    std::cout << "Scheduler tests passed!" << std::endl;
+    return;
+}
+
+

--- a/tests/test_shared_state.cpp
+++ b/tests/test_shared_state.cpp
@@ -1,0 +1,103 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../src/AST/Node.hpp"
+#include "../src/Interpreter.hpp"
+#include "../src/Lexer.hpp"
+#include "../src/Parser.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace o2l;
+
+namespace {
+
+// A coroutine node that yields N times, writing a shared counter each time
+class CounterNode : public ASTNode {
+   public:
+    std::string name;
+    int yields;
+    std::vector<std::string>* log;
+
+    CounterNode(std::string n, int y, std::vector<std::string>* l)
+        : name(std::move(n)), yields(y), log(l) {}
+
+    Value evaluate(Context& context) override {
+        (void)context;
+        auto& sched = Scheduler::instance();
+        if (sched.hasResumeValue()) {
+            sched.consumeResumeValue();
+        }
+        while (yields > 0) {
+            log->push_back(name + "_" + std::to_string(yields));
+            yields--;
+            sched.yield();
+        }
+        log->push_back(name + "_done");
+        return Value(static_cast<Int>(0));
+    }
+    std::string toString() const override { return name; }
+};
+
+}  // anonymous namespace
+
+// AC#1: two coroutines communicate via channel, verify correct values
+TEST(ConcurrencyTest, channel_producer_consumer_values) {
+    std::string source = R"(
+        Object Main {
+            method main(): Int {
+                ch: Channel = Channel.new(3)
+                spawn {
+                    ch.send(10)
+                    ch.send(20)
+                    ch.send(30)
+                }
+                v1: Int = ch.receive()
+                v2: Int = ch.receive()
+                v3: Int = ch.receive()
+                return v1 + v2 + v3
+            }
+        }
+    )";
+
+    Interpreter interpreter;
+    Lexer lexer(source);
+    auto nodes = Parser(lexer.tokenizeAll()).parse();
+    Value result = interpreter.execute(nodes);
+
+    ASSERT_TRUE(std::holds_alternative<Int>(result));
+    EXPECT_EQ(std::get<Int>(result), 60);
+}
+
+// AC#2: three coroutines yield in deterministic round-robin order with shared log
+TEST(ConcurrencyTest, three_coroutine_round_robin) {
+    auto& sched = Scheduler::instance();
+    sched.reset();
+
+    std::vector<std::string> log;
+    auto a = std::make_unique<CounterNode>("A", 2, &log);
+    auto b = std::make_unique<CounterNode>("B", 2, &log);
+    auto c = std::make_unique<CounterNode>("C", 2, &log);
+
+    sched.spawn(a.get(), Context());
+    sched.spawn(b.get(), Context());
+    sched.spawn(c.get(), Context());
+    sched.run();
+
+    // Round-robin: A yields, B yields, C yields, A yields, B yields, C yields,
+    // then A done, B done, C done
+    ASSERT_EQ(log.size(), 9u);
+    EXPECT_EQ(log[0], "A_2");
+    EXPECT_EQ(log[1], "B_2");
+    EXPECT_EQ(log[2], "C_2");
+    EXPECT_EQ(log[3], "A_1");
+    EXPECT_EQ(log[4], "B_1");
+    EXPECT_EQ(log[5], "C_1");
+    EXPECT_EQ(log[6], "A_done");
+    EXPECT_EQ(log[7], "B_done");
+    EXPECT_EQ(log[8], "C_done");
+}

--- a/tests/test_spawn_basic.cpp
+++ b/tests/test_spawn_basic.cpp
@@ -1,0 +1,60 @@
+﻿#include <cassert>
+#include <iostream>
+#include <memory>
+#include <variant>
+
+#include "../src/Lexer.hpp"
+#include "../src/Parser.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/CoroutineHandle.hpp"
+#include "../src/Runtime/Scheduler.hpp"
+
+using namespace o2l;
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, spawn_basic) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Testing Lexer + Parser + SpawnNode::evaluate()..." << std::endl;
+
+    std::string source = "spawn { var x: Int = 42; }";
+    Lexer lexer(source);
+    auto tokens = lexer.tokenizeAll();
+
+    // Verify Lexer
+    bool has_spawn = false;
+    for (const auto& t : tokens) {
+        if (t.type == TokenType::SPAWN) has_spawn = true;
+    }
+    assert(has_spawn);
+    std::cout << "  [âœ“] Lexer recognized SPAWN." << std::endl;
+
+    // Verify Parser
+    Parser parser(tokens);
+    auto nodes = parser.parse();
+    assert(nodes.size() == 1);
+
+    // We need to use dynamic_cast but SpawnNode is in AST namespace usually?
+    // No, it's in o2l namespace.
+    // assert(dynamic_cast<SpawnNode*>(nodes[0].get()) != nullptr);
+    std::cout << "  [âœ“] Parser created nodes." << std::endl;
+
+    // Verify Evaluator
+    Context context;
+    Value result = nodes[0]->evaluate(context);
+
+    // Result should be a CoroutineHandle
+    assert(std::holds_alternative<std::shared_ptr<CoroutineHandle>>(result));
+    auto handle = std::get<std::shared_ptr<CoroutineHandle>>(result);
+    assert(handle->getId() == 0);
+    std::cout << "  [âœ“] SpawnNode::evaluate() returned CoroutineHandle." << std::endl;
+
+    // Verify coroutine is in scheduler
+    auto& sched = Scheduler::instance();
+    // We can't easily check private queues but we know it returned ID 0
+
+    std::cout << "Spawn integration tests passed!" << std::endl;
+    return;
+}
+
+

--- a/tests/test_suspend_exception.cpp
+++ b/tests/test_suspend_exception.cpp
@@ -1,0 +1,117 @@
+﻿#include "../src/Runtime/Scheduler.hpp"
+#include <cassert>
+#include <iostream>
+#include <memory>
+
+#include "../src/AST/BinaryOpNode.hpp"
+#include "../src/AST/BlockNode.hpp"
+#include "../src/AST/ComparisonNode.hpp"
+#include "../src/AST/IdentifierNode.hpp"
+#include "../src/AST/LiteralNode.hpp"
+#include "../src/AST/Node.hpp"
+#include "../src/AST/VariableAssignmentNode.hpp"
+#include "../src/AST/VariableDeclarationNode.hpp"
+#include "../src/AST/WhileStatementNode.hpp"
+#include "../src/Common/Exceptions.hpp"
+#include "../src/Common/SourceLocation.hpp"
+#include "../src/Lexer.hpp"
+#include "../src/Runtime/Context.hpp"
+#include "../src/Runtime/Value.hpp"
+
+using namespace o2l;
+
+// A custom AST node that throws SuspendException to simulate a yield point
+class YieldNode : public ASTNode {
+   public:
+    int* call_count;
+    explicit YieldNode(int* count) : call_count(count) {}
+
+    Value evaluate(Context& context) override {
+        (*call_count)++;
+        throw SuspendException("test_yield");
+    }
+
+    std::string toString() const override {
+        return "yield";
+    }
+};
+
+#include <gtest/gtest.h>
+
+TEST(ConcurrencyTest, suspend_exception) {
+    o2l::Scheduler::instance().reset();
+    std::cout << "Running task-001: SuspendException Spike..." << std::endl;
+
+    Context context;
+    int yield_calls = 0;
+
+    /*
+     * Build AST manually:
+     * var count: Int = 0;
+     * while (count < 3) {
+     *   yield;
+     *   count = count + 1;
+     * }
+     */
+
+    SourceLocation loc;
+
+    // var count: Int = 0;
+    auto var_decl = std::make_unique<VariableDeclarationNode>(
+        "count", "Int", std::make_unique<LiteralNode>(Int(0)));
+
+    // count < 3
+    auto condition = std::make_unique<ComparisonNode>(std::make_unique<IdentifierNode>("count"),
+                                                      ComparisonOperator::LESS_THAN,
+                                                      std::make_unique<LiteralNode>(Int(3)), loc);
+
+    // yield;
+    auto yield_stmt = std::make_unique<YieldNode>(&yield_calls);
+
+    // count = count + 1;
+    auto increment = std::make_unique<VariableAssignmentNode>(
+        "count", std::make_unique<BinaryOpNode>(std::make_unique<IdentifierNode>("count"),
+                                                BinaryOperator::PLUS,
+                                                std::make_unique<LiteralNode>(Int(1)), loc));
+
+    // { yield; count = count + 1; }
+    std::vector<ASTNodePtr> body_stmts;
+    body_stmts.push_back(std::move(yield_stmt));
+    body_stmts.push_back(std::move(increment));
+    auto body = std::make_unique<BlockNode>(std::move(body_stmts));
+
+    // while (count < 3) { ... }
+    auto while_stmt = std::make_unique<WhileStatementNode>(std::move(condition), std::move(body));
+
+    // Initial declaration
+    var_decl->evaluate(context);
+
+    // Simulate the scheduler loop
+    int loops = 0;
+    while (loops < 10) {  // Safety break
+        try {
+            while_stmt->evaluate(context);
+            std::cout << "  While loop completed normally." << std::endl;
+            break;
+        } catch (const SuspendException& e) {
+            std::cout << "  Caught SuspendException: " << e.getReason() << std::endl;
+
+            // SIMULATE RESUME: In a real scheduler, we would resume from the exact statement.
+            // Here, to make it progress without statement tracking, we manually increment count.
+            // This still proves that the exception unwound correctly through AST nodes.
+            Value c = context.getVariable("count");
+            context.reassignVariable("count", Int(std::get<Int>(c) + 1));
+        }
+        loops++;
+    }
+
+    // Verification
+    assert(yield_calls > 0);
+    std::cout << "Spike Successful: SuspendException unwound correctly through nested AST nodes."
+              << std::endl;
+
+    return;
+}
+
+
+

--- a/tests/test_suspend_exception.cpp
+++ b/tests/test_suspend_exception.cpp
@@ -20,6 +20,8 @@
 
 using namespace o2l;
 
+namespace {
+
 // A custom AST node that throws SuspendException to simulate a yield point
 class YieldNode : public ASTNode {
    public:
@@ -35,6 +37,8 @@ class YieldNode : public ASTNode {
         return "yield";
     }
 };
+
+}  // anonymous namespace
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Closes #9

## Summary

- Adds `spawn <expr>` keyword to launch cooperative coroutines within the same OS thread
- Introduces `Scheduler` singleton run-loop with ready/timer/suspended queues and correct exception propagation from the root coroutine
- `ChannelInstance` provides buffered/unbuffered send/receive with suspend-on-full / suspend-on-empty semantics
- `IOThreadPool` offloads blocking work to background threads; coroutines resume via `Scheduler::resumeCoroutine`
- `Context::clone()` isolates each coroutine's variable bindings from the spawning scope
- `ConcurrencyLibrary` exposes `Channel.new(capacity)`, `io.sleep(ms)`, `io.yield()` to O²L programs
- `CArray.fromList()` completes the FFI bridge for async callback use

## Test plan

- [ ] `test_scheduler.cpp` — run-loop, multi-coroutine scheduling, exception propagation
- [ ] `test_spawn_basic.cpp` — `spawn` keyword end-to-end
- [ ] `test_channel_basic.cpp` — send/receive, buffering, blocking
- [ ] `test_resume_logic.cpp` — `suspendCurrent` / `resumeCoroutine` round-trip
- [ ] `test_io_yield.cpp` — `yield` and `sleep` integration
- [ ] `test_suspend_exception.cpp` — exception propagation through coroutines
- [ ] `test_context_clone.cpp` — context isolation between coroutines
- [ ] `test_carray_from_list.cpp` — `CArray.fromList()` correctness
- [ ] All 464 tests pass (464 total including pre-existing suite)