### PR TITLE
feat: extend Text API with substring(), charAt(), contains(), and trim aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌟 O²L Programming Language
 
-[![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/zombocoder/o2l) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![C++ Version](https://img.shields.io/badge/C++-23-blue.svg)](https://en.cppreference.com/w/cpp/23) [![Tests](https://img.shields.io/badge/tests-445%20passing-brightgreen.svg)](https://github.com/zombocoder/o2l) [![FFI System](https://img.shields.io/badge/FFI-SQLite%20integrated-brightgreen.svg)](https://github.com/zombocoder/o2l) [![Text Methods](https://img.shields.io/badge/text%20methods-48-blue.svg)](https://github.com/zombocoder/o2l) [![HTTP Client](https://img.shields.io/badge/http%20methods-30+-brightgreen.svg)](https://github.com/zombocoder/o2l) [![JSON Library](https://img.shields.io/badge/json%20methods-30+-brightgreen.svg)](https://github.com/zombocoder/o2l) [![URL Library](https://img.shields.io/badge/url%20methods-26-blue.svg)](https://github.com/zombocoder/o2l) [![Regexp Library](https://img.shields.io/badge/regexp%20methods-12-blue.svg)](https://github.com/zombocoder/o2l) [![Math Library](https://img.shields.io/badge/math%20functions-40+-brightgreen.svg)](https://github.com/zombocoder/o2l) [![DateTime Library](https://img.shields.io/badge/datetime%20functions-65+-blue.svg)](https://github.com/zombocoder/o2l)
+[![Build Status](https://img.shields.io/badge/build-passing-brightgreen.svg)](https://github.com/zombocoder/o2l) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![C++ Version](https://img.shields.io/badge/C++-23-blue.svg)](https://en.cppreference.com/w/cpp/23) [![Tests](https://img.shields.io/badge/tests-445%20passing-brightgreen.svg)](https://github.com/zombocoder/o2l) [![FFI System](https://img.shields.io/badge/FFI-SQLite%20integrated-brightgreen.svg)](https://github.com/zombocoder/o2l) [![Text Methods](https://img.shields.io/badge/text%20methods-54-blue.svg)](https://github.com/zombocoder/o2l) [![HTTP Client](https://img.shields.io/badge/http%20methods-30+-brightgreen.svg)](https://github.com/zombocoder/o2l) [![JSON Library](https://img.shields.io/badge/json%20methods-30+-brightgreen.svg)](https://github.com/zombocoder/o2l) [![URL Library](https://img.shields.io/badge/url%20methods-26-blue.svg)](https://github.com/zombocoder/o2l) [![Regexp Library](https://img.shields.io/badge/regexp%20methods-12-blue.svg)](https://github.com/zombocoder/o2l) [![Math Library](https://img.shields.io/badge/math%20functions-40+-brightgreen.svg)](https://github.com/zombocoder/o2l) [![DateTime Library](https://img.shields.io/badge/datetime%20functions-65+-blue.svg)](https://github.com/zombocoder/o2l)
 
 **O²L** is a modern object-oriented programming language that balances pure object-oriented design with practical programming constructs. Built with C++23, O²L eliminates primitives and null values while providing essential control flow like while loops, comprehensive arithmetic operations, and extensive string manipulation capabilities for real-world programming needs.
 
@@ -20,7 +20,7 @@
 - **⏭️ Continue Statements**: `continue` statement for skipping iterations in while loops, perfect for filtering and validation
 - **📏 Text Length Method**: `Text.length()` method for string length calculation with full type integration
 - **📐 Math Library**: Comprehensive mathematical functions library with 40+ methods including trigonometry, logarithms, statistics, and constants (`import math`)
-- **✨ Comprehensive Text Methods**: 48 string manipulation methods including case conversion, search, validation, formatting, and advanced utilities
+- **✨ Comprehensive Text Methods**: 54 string manipulation methods including case conversion, search, validation, formatting, and advanced utilities
 - **🔄 Variable Mutability**: Method-scope variables are mutable while object properties remain immutable
 - **🧠 Logical Operators**: Full `&&`, `||`, `!` support with proper precedence and short-circuit evaluation
 - **📁 Filesystem Operations**: Complete `system.fs` module for file/directory management
@@ -33,7 +33,7 @@
 
 ### **Everything is an Object**
 
-In O²L, there are no primitives. Numbers, booleans, strings—everything is an object with methods and behaviors. This creates a unified, consistent programming model where all values follow the same patterns. For example, Text objects provide 47 comprehensive methods for manipulation, validation, and formatting, treating strings as first-class objects rather than simple data.
+In O²L, there are no primitives. Numbers, booleans, strings—everything is an object with methods and behaviors. This creates a unified, consistent programming model where all values follow the same patterns. For example, Text objects provide 50 comprehensive methods for manipulation, validation, and formatting, treating strings as first-class objects rather than simple data.
 
 ### **Immutability by Design**
 
@@ -432,7 +432,7 @@ cd build/tests
 # ⚡ 44 Runtime tests - Value types, collections, iterators
 # 🔌 20 Protocol tests - Interface compliance and signature validation
 # 🚀 35 Integration tests - End-to-end execution
-# ✨ 12 Text method tests - All 48 string methods including length()
+# ✨ 12 Text method tests - All 54 string methods including length()
 # 📐 12 Math library tests - All mathematical functions and constants
 # 🔄 JSON Library - 16 comprehensive tests covering parsing, path navigation, validation, and native collection integration
 # 🌐 HTTP Client - 24 extensive tests covering all HTTP methods, authentication, file operations, and error handling

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Welcome to the comprehensive documentation for the O²L programming language. Th
 
 ### Core Types Reference
 
-- **[Text](api-reference/core/Text.md)** - String manipulation and text processing (48+ methods)
+- **[Text](api-reference/core/Text.md)** - String manipulation and text processing (54+ methods)
 - **[List](api-reference/core/List.md)** - Dynamic arrays and list operations
 - **[Map](api-reference/core/Map.md)** - Key-value data structures
 - **[Set](api-reference/core/Set.md)** - Unique value collections

--- a/docs/api-reference/core/README.md
+++ b/docs/api-reference/core/README.md
@@ -5,7 +5,7 @@ O²L provides a rich set of built-in types for common programming tasks. Each ty
 ## Data Types Overview
 
 ### Primitive Types
-- **[Text](Text.md)** - Unicode strings with 48+ methods for manipulation
+- **[Text](Text.md)** - Unicode strings with 54+ methods for manipulation
 - **[Int](Numeric.md#int)** - 32-bit signed integers
 - **[Long](Numeric.md#long)** - 64-bit signed integers  
 - **[Float](Numeric.md#float)** - 32-bit floating point numbers

--- a/docs/api-reference/core/Text.md
+++ b/docs/api-reference/core/Text.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Text type is O²L's immutable string implementation with 48+ methods for string manipulation, validation, and formatting. All Text operations return new Text instances, maintaining immutability.
+The Text type is O²L's immutable string implementation with 54+ methods for string manipulation, validation, and formatting. All Text operations return new Text instances, maintaining immutability.
 
 ## Constructor
 
@@ -101,6 +101,16 @@ Returns the lowest index where substring is found, or -1 if not found.
 text: Text = "Hello World"
 index: Int = text.find("World")  // Returns 6
 missing: Int = text.find("xyz")  // Returns -1
+```
+
+### `contains(substring: Text) → Bool`
+
+Returns true if the text contains the given substring.
+
+```o2l
+text: Text = "Hello World"
+result: Bool = text.contains("World")  // true
+result: Bool = text.contains("xyz")    // false
 ```
 
 ### `rfind(substring: Text) → Int`
@@ -278,31 +288,34 @@ result: Bool = text.isTitle()  // Returns true
 
 ## String Manipulation
 
-### `strip() → Text`
+### `strip() → Text` / `trim() → Text`
 
-Returns a copy with leading and trailing whitespace removed.
+Returns a copy with leading and trailing whitespace removed. `trim()` is an alias for `strip()`.
 
 ```o2l
 text: Text = "  Hello World  "
 result: Text = text.strip()  // "Hello World"
+result: Text = text.trim()   // "Hello World" (alias)
 ```
 
-### `lstrip() → Text`
+### `lstrip() → Text` / `trimStart() → Text`
 
-Returns a copy with leading whitespace removed.
+Returns a copy with leading whitespace removed. `trimStart()` is an alias for `lstrip()`.
 
 ```o2l
 text: Text = "  Hello World  "
-result: Text = text.lstrip()  // "Hello World  "
+result: Text = text.lstrip()     // "Hello World  "
+result: Text = text.trimStart()  // "Hello World  " (alias)
 ```
 
-### `rstrip() → Text`
+### `rstrip() → Text` / `trimEnd() → Text`
 
-Returns a copy with trailing whitespace removed.
+Returns a copy with trailing whitespace removed. `trimEnd()` is an alias for `rstrip()`.
 
 ```o2l
 text: Text = "  Hello World  "
-result: Text = text.rstrip()  // "  Hello World"
+result: Text = text.rstrip()   // "  Hello World"
+result: Text = text.trimEnd()  // "  Hello World" (alias)
 ```
 
 ### `replace(old: Text, new: Text) → Text`
@@ -312,6 +325,27 @@ Returns a copy with all occurrences of old replaced by new.
 ```o2l
 text: Text = "Hello World"
 result: Text = text.replace("World", "Universe")  // "Hello Universe"
+```
+
+### `substring(start: Int, end: Int) → Text`
+
+Returns the substring from `start` (inclusive) to `end` (exclusive). Supports negative indices (count from end, Python-style). Out-of-bounds indices are clamped. Returns empty string if `start >= end`.
+
+```o2l
+text: Text = "Hello World"
+result: Text = text.substring(0, 5)    # "Hello"
+result2: Text = text.substring(-5, 11) # "World"  (-5 resolves to index 6)
+result3: Text = text.substring(0, -6)  # "Hello"  (-6 resolves to index 5)
+```
+
+### `charAt(index: Int) → Text`
+
+Returns the character at `index` as a single-character Text. Supports negative indices (count from end). Throws if index is out of range.
+
+```o2l
+text: Text = "Hello"
+ch: Text = text.charAt(0)   # "H"
+last: Text = text.charAt(-1) # "o"
 ```
 
 ### `split(separator: Text) → List<Text>`

--- a/examples/test_substring_charat.obq
+++ b/examples/test_substring_charat.obq
@@ -1,0 +1,135 @@
+# test_substring_charat.obq — Tests for Text.substring() and Text.charAt()
+
+import system.io
+
+Object TestSubstringCharAt {
+    property passed: Int
+    property failed: Int
+
+    constructor() {
+        this.passed = 0
+        this.failed = 0
+    }
+
+    @external method assert(name: Text, condition: Bool): Text {
+        if (condition) {
+            io.print("  PASS: %s", name)
+            this.passed = this.passed + 1
+        } else {
+            io.print("  FAIL: %s", name)
+            this.failed = this.failed + 1
+        }
+        return "ok"
+    }
+
+    # Test 1: Basic substring
+    @external method testBasicSubstring(): Text {
+        io.print("Test: Basic Substring")
+
+        text: Text = "Hello World"
+        this.assert("substring(0,5) = Hello", text.substring(0, 5) == "Hello")
+        this.assert("substring(6,11) = World", text.substring(6, 11) == "World")
+        this.assert("substring(0,11) = full string", text.substring(0, 11) == "Hello World")
+        this.assert("substring(0,1) = H", text.substring(0, 1) == "H")
+
+        return "ok"
+    }
+
+    # Test 2: Substring with negative indices
+    @external method testNegativeSubstring(): Text {
+        io.print("Test: Negative Index Substring")
+
+        text: Text = "Hello World"
+        this.assert("substring(-5,11) = World", text.substring(-5, 11) == "World")
+        this.assert("substring(0,-6) = Hello", text.substring(0, -6) == "Hello")
+        this.assert("substring(-5,-1) = Worl", text.substring(-5, -1) == "Worl")
+
+        return "ok"
+    }
+
+    # Test 3: Substring edge cases
+    @external method testSubstringEdgeCases(): Text {
+        io.print("Test: Substring Edge Cases")
+
+        text: Text = "Hello"
+        this.assert("start == end => empty", text.substring(3, 3) == "")
+        this.assert("start > end => empty", text.substring(4, 2) == "")
+        this.assert("out of bounds clamped", text.substring(0, 100) == "Hello")
+
+        empty: Text = ""
+        this.assert("empty string substring", empty.substring(0, 0) == "")
+
+        return "ok"
+    }
+
+    # Test 4: Basic charAt
+    @external method testBasicCharAt(): Text {
+        io.print("Test: Basic charAt")
+
+        text: Text = "Hello"
+        this.assert("charAt(0) = H", text.charAt(0) == "H")
+        this.assert("charAt(1) = e", text.charAt(1) == "e")
+        this.assert("charAt(4) = o", text.charAt(4) == "o")
+
+        return "ok"
+    }
+
+    # Test 5: charAt with negative indices
+    @external method testNegativeCharAt(): Text {
+        io.print("Test: Negative Index charAt")
+
+        text: Text = "Hello"
+        this.assert("charAt(-1) = o", text.charAt(-1) == "o")
+        this.assert("charAt(-5) = H", text.charAt(-5) == "H")
+        this.assert("charAt(-3) = l", text.charAt(-3) == "l")
+
+        return "ok"
+    }
+
+    # Test 6: Practical usage — parsing
+    @external method testPracticalUsage(): Text {
+        io.print("Test: Practical Usage")
+
+        path: Text = "/api/users/42"
+        # Extract "api" using substring
+        segment: Text = path.substring(1, 4)
+        this.assert("path segment extraction", segment == "api")
+
+        # First character check
+        this.assert("path starts with /", path.charAt(0) == "/")
+
+        # Last character
+        this.assert("path ends with 2", path.charAt(-1) == "2")
+
+        return "ok"
+    }
+
+    @external method printSummary(): Text {
+        io.print("")
+        io.print("Results: %d passed, %d failed", this.passed, this.failed)
+        if (this.failed == 0) {
+            io.print("All tests passed!")
+        } else {
+            io.print("SOME TESTS FAILED")
+        }
+        return "ok"
+    }
+}
+
+Object Main {
+    method main(): Int {
+        io.print("=== Text.substring() and Text.charAt() Tests ===")
+        io.print("")
+
+        t: TestSubstringCharAt = new TestSubstringCharAt()
+        t.testBasicSubstring()
+        t.testNegativeSubstring()
+        t.testSubstringEdgeCases()
+        t.testBasicCharAt()
+        t.testNegativeCharAt()
+        t.testPracticalUsage()
+        t.printSummary()
+
+        return 0
+    }
+}

--- a/tests/test_text_methods.cpp
+++ b/tests/test_text_methods.cpp
@@ -134,6 +134,21 @@ TEST_F(TextMethodTest, StringSearchMethods) {
 
     // Test rindex (not found) - should throw exception
     EXPECT_THROW({ callTextMethod("Hello World", "rindex", {Text("xyz")}); }, EvaluationError);
+
+    // Test contains
+    result = callTextMethod("Hello World", "contains", {Text("World")});
+    EXPECT_TRUE(std::holds_alternative<Bool>(result));
+    EXPECT_EQ(std::get<Bool>(result), true);
+
+    result = callTextMethod("Hello World", "contains", {Text("xyz")});
+    EXPECT_TRUE(std::holds_alternative<Bool>(result));
+    EXPECT_EQ(std::get<Bool>(result), false);
+
+    result = callTextMethod("Hello World", "contains", {Text("")});
+    EXPECT_EQ(std::get<Bool>(result), true);  // empty string always found
+
+    result = callTextMethod("", "contains", {Text("a")});
+    EXPECT_EQ(std::get<Bool>(result), false);
 }
 
 // Test string boolean check methods
@@ -276,6 +291,26 @@ TEST_F(TextMethodTest, StringManipulationMethods) {
     result = callTextMethod("  Hello World  ", "rstrip");
     EXPECT_TRUE(std::holds_alternative<Text>(result));
     EXPECT_EQ(std::get<Text>(result), "  Hello World");
+
+    // Test trim (alias for strip)
+    result = callTextMethod("  Hello World  ", "trim");
+    EXPECT_TRUE(std::holds_alternative<Text>(result));
+    EXPECT_EQ(std::get<Text>(result), "Hello World");
+
+    // Test trimStart (alias for lstrip)
+    result = callTextMethod("  Hello World  ", "trimStart");
+    EXPECT_TRUE(std::holds_alternative<Text>(result));
+    EXPECT_EQ(std::get<Text>(result), "Hello World  ");
+
+    // Test trimEnd (alias for rstrip)
+    result = callTextMethod("  Hello World  ", "trimEnd");
+    EXPECT_TRUE(std::holds_alternative<Text>(result));
+    EXPECT_EQ(std::get<Text>(result), "  Hello World");
+
+    // Test trim on all-whitespace string
+    result = callTextMethod("   \t\n  ", "trim");
+    EXPECT_TRUE(std::holds_alternative<Text>(result));
+    EXPECT_EQ(std::get<Text>(result), "");
 
     // Test replace
     result = callTextMethod("Hello World", "replace", {Text("World"), Text("Universe")});
@@ -428,6 +463,88 @@ TEST_F(TextMethodTest, TranslationMethods) {
     result = callTextMethod("abcdef", "translate", {Value(trans_table)});
     EXPECT_TRUE(std::holds_alternative<Text>(result));
     EXPECT_EQ(std::get<Text>(result), "xyzdef");
+}
+
+// Test substring and charAt methods
+TEST_F(TextMethodTest, SubstringAndCharAtMethods) {
+    // Test basic substring
+    Value result = callTextMethod("Hello World", "substring", {Int(0), Int(5)});
+    EXPECT_TRUE(std::holds_alternative<Text>(result));
+    EXPECT_EQ(std::get<Text>(result), "Hello");
+
+    // Test substring in the middle
+    result = callTextMethod("Hello World", "substring", {Int(6), Int(11)});
+    EXPECT_EQ(std::get<Text>(result), "World");
+
+    // Test substring with negative indices (Python-style)
+    result = callTextMethod("Hello World", "substring", {Int(-5), Int(-0)});
+    // -5 resolves to 6, -0 is 0 so start >= end => ""
+    // Actually -0 in Int is just 0. start=6, end=0 => start >= end => ""
+    EXPECT_EQ(std::get<Text>(result), "");
+
+    // Negative end that resolves
+    result = callTextMethod("Hello World", "substring", {Int(0), Int(-6)});
+    // -6 resolves to len(11) + (-6) = 5 => substring(0, 5) = "Hello"
+    EXPECT_EQ(std::get<Text>(result), "Hello");
+
+    // Negative start
+    result = callTextMethod("Hello World", "substring", {Int(-5), Int(11)});
+    // -5 resolves to 11 + (-5) = 6 => substring(6, 11) = "World"
+    EXPECT_EQ(std::get<Text>(result), "World");
+
+    // Both negative
+    result = callTextMethod("Hello World", "substring", {Int(-5), Int(-1)});
+    // -5 => 6, -1 => 10 => substring(6, 10) = "Worl"
+    EXPECT_EQ(std::get<Text>(result), "Worl");
+
+    // Out of bounds clamped
+    result = callTextMethod("Hello", "substring", {Int(0), Int(100)});
+    EXPECT_EQ(std::get<Text>(result), "Hello");
+
+    // start == end => empty
+    result = callTextMethod("Hello", "substring", {Int(3), Int(3)});
+    EXPECT_EQ(std::get<Text>(result), "");
+
+    // start > end => empty
+    result = callTextMethod("Hello", "substring", {Int(4), Int(2)});
+    EXPECT_EQ(std::get<Text>(result), "");
+
+    // Empty string
+    result = callTextMethod("", "substring", {Int(0), Int(0)});
+    EXPECT_EQ(std::get<Text>(result), "");
+
+    // Test substring error: wrong arg count
+    EXPECT_THROW({ callTextMethod("Hello", "substring", {Int(1)}); }, EvaluationError);
+    EXPECT_THROW({ callTextMethod("Hello", "substring", {}); }, EvaluationError);
+
+    // Test substring error: wrong arg types
+    EXPECT_THROW({ callTextMethod("Hello", "substring", {Text("a"), Int(1)}); }, EvaluationError);
+
+    // --- charAt tests ---
+
+    // Basic charAt
+    result = callTextMethod("Hello", "charAt", {Int(0)});
+    EXPECT_TRUE(std::holds_alternative<Text>(result));
+    EXPECT_EQ(std::get<Text>(result), "H");
+
+    result = callTextMethod("Hello", "charAt", {Int(4)});
+    EXPECT_EQ(std::get<Text>(result), "o");
+
+    // Negative index
+    result = callTextMethod("Hello", "charAt", {Int(-1)});
+    EXPECT_EQ(std::get<Text>(result), "o");
+
+    result = callTextMethod("Hello", "charAt", {Int(-5)});
+    EXPECT_EQ(std::get<Text>(result), "H");
+
+    // Out of range throws
+    EXPECT_THROW({ callTextMethod("Hello", "charAt", {Int(5)}); }, EvaluationError);
+    EXPECT_THROW({ callTextMethod("Hello", "charAt", {Int(-6)}); }, EvaluationError);
+    EXPECT_THROW({ callTextMethod("", "charAt", {Int(0)}); }, EvaluationError);
+
+    // Wrong arg count/type
+    EXPECT_THROW({ callTextMethod("Hello", "charAt", {}); }, EvaluationError);
+    EXPECT_THROW({ callTextMethod("Hello", "charAt", {Text("a")}); }, EvaluationError);
 }
 
 // Test error cases


### PR DESCRIPTION
Closes #6

## Summary

- `substring(start, end)` — positional slice with negative index support (Python-style) and bounds clamping
- `charAt(index)` — single character by index; throws on out-of-range; supports negative indices
- `contains(substring)` — boolean membership check, avoids `!= -1` boilerplate from `find()`
- `trim()` — alias for `strip()`
- `trimStart()` — alias for `lstrip()`
- `trimEnd()` — alias for `rstrip()`

No new AST nodes or parser changes — all six methods dispatch through the existing `MethodCallNode` Text branch.

## Test plan

- [ ] `substring`: basic slice, negative indices, clamping, start≥end → empty, wrong arg types
- [ ] `charAt`: positive index, negative index, out-of-range throws, wrong arg types
- [ ] `contains`: found, not found, empty needle, empty haystack
- [ ] `trim` / `trimStart` / `trimEnd`: whitespace stripping, all-whitespace string
- [ ] All 461 tests pass